### PR TITLE
feat: allow for gathering of templates and file from server

### DIFF
--- a/cmd/agent/commands/run.go
+++ b/cmd/agent/commands/run.go
@@ -43,6 +43,8 @@ func deleteLockFile() {
 func runAgent(client *client.Client, environment string) {
 	// Create rawCatalog
 	var rawCatalog models.RawCatalog
+	rawCatalog.Environment = environment
+	rawCatalog.ApiClient = client
 
 	// Collect facts
 	var err error

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -47,6 +47,7 @@ func NewApiEngine(conf *config.ServerConfig, certsDatabaseEngine *certs.CertsDat
 
 	// Catalogs group
 	catalogsGroup := v1.Group("catalogs")
+	catalogsGroup.Use(mtlsMiddleware)
 
 	// -- Catalogs group needs access to server configuration
 	catalogsGroup.Use(func(c fiber.Ctx) error {
@@ -55,8 +56,21 @@ func NewApiEngine(conf *config.ServerConfig, certsDatabaseEngine *certs.CertsDat
 	})
 
 	// -- Catalogs group endpoints
-	catalogsGroup.Use(mtlsMiddleware)
 	catalogsGroup.Post("/catalog", endpoints.PostRetrieveCatalog)
+
+	// Data group
+	dataGroup := v1.Group("data")
+	dataGroup.Use(mtlsMiddleware)
+
+	// -- Data group needs access to server configuration
+	dataGroup.Use(func(c fiber.Ctx) error {
+		c.Locals("config", conf)
+		return c.Next()
+	})
+
+	// -- Data group endpoints
+	dataGroup.Post("/file", endpoints.PostRetrieveFile)
+	dataGroup.Post("/template", endpoints.PostRetrieveTemplate)
 
 	return app, nil
 }

--- a/pkg/api/client/data.go
+++ b/pkg/api/client/data.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/peeklapp/peekl/pkg/api/requests"
+	"github.com/peeklapp/peekl/pkg/api/responses"
+)
+
+func (c *Client) RetrieveFile(filename string, environment string, roleName string) (string, error) {
+	endpoint := "/v1/data/file"
+	body := requests.RetrieveFile{Filename: filename, Environment: environment, RoleName: roleName}
+	var resp responses.RetrieveFile
+
+	err := c.post(endpoint, &body, &resp)
+	if err != nil {
+		if errors.Is(err, HttpError{}) {
+			detailedError, _ := err.(HttpError)
+			return "", fmt.Errorf("Status code : %d. Details : %+v", detailedError.StatusCode, detailedError.ErrorBody)
+		} else {
+			return "", err
+		}
+	}
+
+	return resp.Content, nil
+}
+
+func (c *Client) RetrieveTemplate(templateName string, environment string, roleName string) (string, error) {
+	endpoint := "/v1/data/template"
+	body := requests.RetrieveTemplate{TemplateName: templateName, Environment: environment, RoleName: roleName}
+	var resp responses.RetrieveTemplate
+
+	err := c.post(endpoint, &body, &resp)
+	if err != nil {
+		if errors.Is(err, HttpError{}) {
+			detailedError, _ := err.(HttpError)
+			return "", fmt.Errorf("Status code : %d. Details: %+v", detailedError.StatusCode, detailedError.ErrorBody)
+		} else {
+			return "", err
+		}
+	}
+
+	return resp.Content, nil
+}

--- a/pkg/api/endpoints/catalogs.go
+++ b/pkg/api/endpoints/catalogs.go
@@ -4,12 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/peeklapp/peekl/pkg/api/requests"
 	"github.com/peeklapp/peekl/pkg/api/responses"
 	"github.com/peeklapp/peekl/pkg/catalog"
 	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/peeklapp/peekl/pkg/environments"
 	"github.com/peeklapp/peekl/pkg/models"
 )
 
@@ -24,7 +26,16 @@ func PostRetrieveCatalog(ctx fiber.Ctx) error {
 	}
 
 	conf, _ := ctx.Locals("config").(*config.ServerConfig)
-	directoryPath := fmt.Sprintf("%s/%s", conf.Code.Directory, input.Environment)
+
+	if !environments.EnvironmentNameIsValid(input.Environment) {
+		ctx.Status(400).JSON(responses.ErrorResponse{
+			Error:   "Environment name is not valid",
+			Details: fmt.Sprintf("The provided environment name %s is not valid", input.Environment),
+		})
+		return nil
+	}
+
+	directoryPath := path.Join(conf.Code.Directory, input.Environment)
 	nodeName := ctx.RequestCtx().TLSConnectionState().PeerCertificates[0].Subject.CommonName
 
 	if _, err := os.Stat(directoryPath); os.IsNotExist(err) {

--- a/pkg/api/endpoints/data.go
+++ b/pkg/api/endpoints/data.go
@@ -1,0 +1,210 @@
+package endpoints
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/peeklapp/peekl/pkg/api/requests"
+	"github.com/peeklapp/peekl/pkg/api/responses"
+	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/peeklapp/peekl/pkg/environments"
+	"github.com/peeklapp/peekl/pkg/models"
+	"github.com/peeklapp/peekl/pkg/roles"
+)
+
+func PostRetrieveFile(ctx fiber.Ctx) error {
+	var input requests.RetrieveFile
+	if err := ctx.Bind().Body(&input); err != nil {
+		ctx.Status(400).JSON(responses.ErrorResponse{
+			Error:   "Body Invalid",
+			Details: err.Error(),
+		})
+		return nil
+	}
+
+	conf, _ := ctx.Locals("config").(*config.ServerConfig)
+
+	if !roles.RoleNameIsValid(input.RoleName) {
+		ctx.Status(400).JSON(responses.ErrorResponse{
+			Error:   "Role name is not valid",
+			Details: fmt.Sprintf("The provided role name (%s) is not valid.", input.RoleName),
+		})
+		return nil
+	}
+
+	if !environments.EnvironmentNameIsValid(input.Environment) {
+		ctx.Status(400).JSON(responses.ErrorResponse{
+			Error:   "Environment name is not valid",
+			Details: fmt.Sprintf("The provided environment name (%s) is not valid.", input.Environment),
+		})
+	}
+
+	envPath := filepath.Join(conf.Code.Directory, input.Environment)
+	err := roles.DoesRoleExist(envPath, input.RoleName)
+	if err != nil {
+		if errors.As(err, &models.RoleNotFoundError{}) {
+			ctx.Status(404).JSON(responses.ErrorResponse{
+				Error:   "Role could not be found",
+				Details: err.Error(),
+			})
+			return nil
+		} else {
+			ctx.Status(500).JSON(responses.ErrorResponse{
+				Error:   "Internal Server Error",
+				Details: err.Error(),
+			})
+			return nil
+		}
+	}
+
+	roleFilesPath := path.Join(envPath, "roles", input.RoleName, "files")
+	root, err := os.OpenRoot(roleFilesPath)
+	if err != nil {
+		ctx.Status(500).JSON(responses.ErrorResponse{
+			Error:   "Internal Server Error",
+			Details: err.Error(),
+		})
+	}
+
+	if _, err := root.Stat(input.Filename); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			ctx.Status(400).JSON(responses.ErrorResponse{
+				Error: "The file does not exist",
+				Details: fmt.Sprintf(
+					"The file '%s' could not be found inside of the role '%s' for environment '%s'",
+					input.Filename,
+					input.RoleName,
+					input.Environment,
+				),
+			})
+			return nil
+		} else {
+			ctx.Status(500).JSON(responses.ErrorResponse{
+				Error:   "Internal Server Error",
+				Details: err.Error(),
+			})
+			return nil
+		}
+	}
+
+	fileContent, err := root.ReadFile(input.Filename)
+	if err != nil {
+		ctx.Status(500).JSON(responses.ErrorResponse{
+			Error:   "Internal Server Error",
+			Details: err.Error(),
+		})
+	}
+
+	ctx.Status(200).JSON(responses.RetrieveFile{
+		Filename: input.Filename,
+		Content:  string(fileContent),
+	})
+	return nil
+}
+
+func PostRetrieveTemplate(ctx fiber.Ctx) error {
+	var input requests.RetrieveTemplate
+	if err := ctx.Bind().Body(&input); err != nil {
+		ctx.Status(400).JSON(responses.ErrorResponse{
+			Error:   "Body Invalid",
+			Details: err.Error(),
+		})
+		return nil
+	}
+
+	conf, ok := ctx.Locals("config").(*config.ServerConfig)
+	if !ok {
+		ctx.Status(500).JSON(responses.ErrorResponse{
+			Error: "Not OK !!!",
+		})
+	}
+
+	if !roles.RoleNameIsValid(input.RoleName) {
+		ctx.Status(400).JSON(responses.ErrorResponse{
+			Error:   "Role name is not valid",
+			Details: fmt.Sprintf("The provided role name (%s) is not valid.", input.RoleName),
+		})
+		return nil
+	}
+
+	if !environments.EnvironmentNameIsValid(input.Environment) {
+		ctx.Status(400).JSON(responses.ErrorResponse{
+			Error:   "Environment name is not valid",
+			Details: fmt.Sprintf("The provided environment name (%s) is not valid.", input.Environment),
+		})
+	}
+
+	envPath := filepath.Join(conf.Code.Directory, input.Environment)
+	err := roles.DoesRoleExist(envPath, input.RoleName)
+	if err != nil {
+		if errors.As(err, &models.RoleNotFoundError{}) {
+			ctx.Status(404).JSON(responses.ErrorResponse{
+				Error:   "Role could not be found",
+				Details: err.Error(),
+			})
+			return nil
+		} else {
+			ctx.Status(500).JSON(responses.ErrorResponse{
+				Error:   "Internal Server Error",
+				Details: err.Error(),
+			})
+			return nil
+		}
+	}
+
+	roleTemplatesPath := path.Join(envPath, "roles", input.RoleName, "templates")
+	root, err := os.OpenRoot(roleTemplatesPath)
+	if err != nil {
+		ctx.Status(500).JSON(responses.ErrorResponse{
+			Error:   "Internal Server Error",
+			Details: err.Error(),
+		})
+	}
+
+	var templateName string
+	if strings.HasSuffix(input.TemplateName, ".tmpl") {
+		templateName = input.TemplateName
+	} else {
+		templateName = fmt.Sprintf("%s.tmpl", input.TemplateName)
+	}
+
+	if _, err := root.Stat(templateName); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			ctx.Status(400).JSON(responses.ErrorResponse{
+				Error: "The template does not exist",
+				Details: fmt.Sprintf(
+					"The template '%s' could not be found inside of the role '%s' for environment '%s'",
+					input.TemplateName,
+					input.RoleName,
+					input.Environment,
+				),
+			})
+			return nil
+		} else {
+			ctx.Status(500).JSON(responses.ErrorResponse{
+				Error:   "Internal Server Error",
+				Details: err.Error(),
+			})
+			return nil
+		}
+	}
+
+	fileContent, err := root.ReadFile(templateName)
+	if err != nil {
+		ctx.Status(500).JSON(responses.ErrorResponse{
+			Error:   "Internal Server Error",
+			Details: err.Error(),
+		})
+	}
+
+	ctx.Status(200).JSON(responses.RetrieveFile{
+		Filename: input.TemplateName,
+		Content:  string(fileContent),
+	})
+	return nil
+}

--- a/pkg/api/requests/data.go
+++ b/pkg/api/requests/data.go
@@ -1,0 +1,13 @@
+package requests
+
+type RetrieveFile struct {
+	RoleName    string `json:"role_name"`
+	Environment string `json:"environment"`
+	Filename    string `json:"filename"`
+}
+
+type RetrieveTemplate struct {
+	RoleName     string `json:"role_name"`
+	Environment  string `json:"environment"`
+	TemplateName string `json:"template_name"`
+}

--- a/pkg/api/responses/data.go
+++ b/pkg/api/responses/data.go
@@ -1,0 +1,11 @@
+package responses
+
+type RetrieveFile struct {
+	Filename string
+	Content  string
+}
+
+type RetrieveTemplate struct {
+	TemplateName string
+	Content      string
+}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -116,11 +116,13 @@ func processResources(resources []models.LoadedResource, resContext *models.Reso
 }
 
 type Catalog struct {
-	resources []models.LoadedResource
-	variables map[string]any
-	facts     *models.Facts
-	tags      []string
-	roles     []models.Role
+	resources   []models.LoadedResource
+	variables   map[string]any
+	facts       *models.Facts
+	tags        []string
+	roles       []models.Role
+	environment string
+	apiClient   models.ApiClient
 }
 
 type CatalogResult struct {
@@ -140,6 +142,8 @@ func (c *Catalog) Process() error {
 	resContext.Facts = c.facts
 	resContext.Variables = c.variables
 	resContext.Tags = c.tags
+	resContext.Environment = c.environment
+	resContext.ApiClient = c.apiClient
 
 	logrus.Info(
 		fmt.Sprintf(
@@ -235,7 +239,7 @@ func (c *Catalog) Validate() (bool, error) {
 func (c *Catalog) loadRoles(roles []models.Role) error {
 	for _, role := range roles {
 		// Handle main resources
-		loadedMainResources, err := c.loadResources(role.Resources, &models.RoleContext{Templates: role.Templates})
+		loadedMainResources, err := c.loadResources(role.Resources, &models.RoleContext{RoleName: role.Name})
 		if err != nil {
 			return err
 		}
@@ -243,7 +247,7 @@ func (c *Catalog) loadRoles(roles []models.Role) error {
 
 		// Handle each included
 		for key, include := range role.IncludedResources {
-			loadedIncludedResources, err := c.loadResources(include.Resources, &models.RoleContext{Templates: role.Templates})
+			loadedIncludedResources, err := c.loadResources(include.Resources, &models.RoleContext{RoleName: role.Name})
 			if err != nil {
 				return err
 			}
@@ -264,55 +268,55 @@ func (c *Catalog) loadSingleResource(resource models.Resource, dataField map[str
 
 	switch resource.Type {
 	case "builtin.user":
-		loadedUser, err := user.NewUserResource(&resource, dataField)
+		loadedUser, err := user.NewUserResource(&resource, dataField, roleContext)
 		if err != nil {
 			return nil, err
 		}
 		return loadedUser, nil
 	case "builtin.group":
-		loadedGroup, err := group.NewGroupResource(&resource, dataField)
+		loadedGroup, err := group.NewGroupResource(&resource, dataField, roleContext)
 		if err != nil {
 			return nil, err
 		}
 		return loadedGroup, nil
 	case "builtin.file":
-		loadedFile, err := file.NewFileResource(&resource, dataField)
+		loadedFile, err := file.NewFileResource(&resource, dataField, roleContext)
 		if err != nil {
 			return nil, err
 		}
 		return loadedFile, nil
 	case "builtin.directory":
-		loadedDirectory, err := directory.NewDirectoryResource(&resource, dataField)
+		loadedDirectory, err := directory.NewDirectoryResource(&resource, dataField, roleContext)
 		if err != nil {
 			return nil, err
 		}
 		return loadedDirectory, nil
 	case "builtin.pkg":
-		loadedPkg, err := pkg.NewPackageResource(&resource, dataField)
+		loadedPkg, err := pkg.NewPackageResource(&resource, dataField, roleContext)
 		if err != nil {
 			return nil, err
 		}
 		return loadedPkg, nil
 	case "builtin.template":
-		loadedTemplate, err := template.NewTemplateResource(&resource, dataField, roleContext.Templates)
+		loadedTemplate, err := template.NewTemplateResource(&resource, dataField, roleContext)
 		if err != nil {
 			return nil, err
 		}
 		return loadedTemplate, nil
 	case "builtin.systemd_service":
-		loadedSystemdService, err := systemdservice.NewSystemdServiceResource(&resource, dataField)
+		loadedSystemdService, err := systemdservice.NewSystemdServiceResource(&resource, dataField, roleContext)
 		if err != nil {
 			return nil, err
 		}
 		return loadedSystemdService, nil
 	case "builtin.debug":
-		loadedDebug, err := debug.NewDebugResource(&resource, dataField)
+		loadedDebug, err := debug.NewDebugResource(&resource, dataField, roleContext)
 		if err != nil {
 			return nil, err
 		}
 		return loadedDebug, nil
 	case "builtin.command":
-		loadedCommand, err := command.NewCommandResource(&resource, dataField)
+		loadedCommand, err := command.NewCommandResource(&resource, dataField, roleContext)
 		if err != nil {
 			return nil, err
 		}
@@ -349,6 +353,8 @@ func NewCatalog(rawCatalog models.RawCatalog) (*Catalog, error) {
 	// Add facts and catalog context
 	catalog.variables = rawCatalog.Variables
 	catalog.facts = rawCatalog.Facts
+	catalog.environment = rawCatalog.Environment
+	catalog.apiClient = rawCatalog.ApiClient
 
 	// Load global resources
 	globalLoadedResources, err := catalog.loadResources(rawCatalog.GlobalResources, nil)

--- a/pkg/environments/environments.go
+++ b/pkg/environments/environments.go
@@ -1,0 +1,8 @@
+package environments
+
+import "regexp"
+
+func EnvironmentNameIsValid(environmentName string) bool {
+	r, _ := regexp.Compile("^[A-Za-z0-9_]")
+	return r.MatchString(environmentName)
+}

--- a/pkg/models/catalog.go
+++ b/pkg/models/catalog.go
@@ -6,4 +6,6 @@ type RawCatalog struct {
 	Facts           *Facts
 	Tags            []string
 	Variables       map[string]any
+	Environment     string
+	ApiClient       ApiClient
 }

--- a/pkg/models/client.go
+++ b/pkg/models/client.go
@@ -1,0 +1,10 @@
+package models
+
+type ApiClient interface {
+	GetRootCA() (string, error)
+	SubmitCertificateRequest(string, string) error
+	RetrieveSignedCertificate(string, string) (string, error)
+	GetCatalog(string) ([]Resource, []Role, []string, map[string]any, error)
+	RetrieveFile(string, string, string) (string, error)
+	RetrieveTemplate(string, string, string) (string, error)
+}

--- a/pkg/models/context.go
+++ b/pkg/models/context.go
@@ -1,11 +1,13 @@
 package models
 
 type ResourceContext struct {
-	Facts     *Facts
-	Tags      []string
-	Variables map[string]any
+	Facts       *Facts
+	Tags        []string
+	Variables   map[string]any
+	Environment string
+	ApiClient   ApiClient
 }
 
 type RoleContext struct {
-	Templates map[string]string
+	RoleName string
 }

--- a/pkg/resources/command/command.go
+++ b/pkg/resources/command/command.go
@@ -136,7 +136,7 @@ func (c *CommandResource) Validate() error {
 	return nil
 }
 
-func NewCommandResource(resource *models.Resource, dataField map[string]any) (*CommandResource, error) {
+func NewCommandResource(resource *models.Resource, dataField map[string]any, roleContext *models.RoleContext) (*CommandResource, error) {
 	var commandResource CommandResource
 
 	// Define defaults

--- a/pkg/resources/command/command_test.go
+++ b/pkg/resources/command/command_test.go
@@ -23,7 +23,7 @@ func TestCommand(t *testing.T) {
 			"command": "echo test > /tmp/testing_file",
 		}
 
-		commandRes, err := NewCommandResource(&rawRes, data)
+		commandRes, err := NewCommandResource(&rawRes, data, nil)
 		if err != nil {
 			t.Errorf("No error should happen at that stage")
 		}
@@ -56,7 +56,7 @@ func TestCommand(t *testing.T) {
 			"creates": "/tmp/testing_file",
 		}
 
-		commandRes, err := NewCommandResource(&rawRes, data)
+		commandRes, err := NewCommandResource(&rawRes, data, nil)
 		if err != nil {
 			t.Errorf("No error should happen at that stage")
 		}

--- a/pkg/resources/debug/debug.go
+++ b/pkg/resources/debug/debug.go
@@ -93,7 +93,7 @@ func (d *DebugResource) Validate() error {
 	return nil
 }
 
-func NewDebugResource(resource *models.Resource, dataField any) (*DebugResource, error) {
+func NewDebugResource(resource *models.Resource, dataField any, roleContext *models.RoleContext) (*DebugResource, error) {
 	var debugResource DebugResource
 
 	debugResource.Title = resource.Title

--- a/pkg/resources/directory/directory.go
+++ b/pkg/resources/directory/directory.go
@@ -251,7 +251,7 @@ func (d *DirectoryResource) Validate() error {
 	return nil
 }
 
-func NewDirectoryResource(resource *models.Resource, dataField any) (*DirectoryResource, error) {
+func NewDirectoryResource(resource *models.Resource, dataField any, roleContext *models.RoleContext) (*DirectoryResource, error) {
 	var directoryResource DirectoryResource
 
 	// Define defaults value

--- a/pkg/resources/file/file.go
+++ b/pkg/resources/file/file.go
@@ -17,11 +17,13 @@ import (
 )
 
 type FileData struct {
-	Path    string      `mapstructure:"path"`
-	Owner   string      `mapstructure:"owner"`
-	Group   string      `mapstructure:"group"`
-	Mode    fs.FileMode `mapstructure:"mode"`
-	Content string      `mapstructure:"content"`
+	Path     string      `mapstructure:"path"`
+	Owner    string      `mapstructure:"owner"`
+	Group    string      `mapstructure:"group"`
+	Mode     fs.FileMode `mapstructure:"mode"`
+	Source   string      `mapstructure:"source"`
+	Content  string      `mapstructure:"content"`
+	roleName string
 }
 
 type FileResource struct {
@@ -125,7 +127,7 @@ func (f *FileResource) changeOwnershipIfNeeded() (bool, error) {
 	return didSomething, nil
 }
 
-func (f *FileResource) changeContentIfNeeded() (bool, error) {
+func (f *FileResource) changeContentIfNeeded(content string) (bool, error) {
 	var didSomething bool
 
 	// First we open the file
@@ -143,7 +145,7 @@ func (f *FileResource) changeContentIfNeeded() (bool, error) {
 
 	// Then we create MD5 object of content
 	contentMD5 := md5.New()
-	io.WriteString(contentMD5, f.Data.Content)
+	io.WriteString(contentMD5, content)
 
 	fileMD5Checksum := fmt.Sprintf("%x", fileMD5.Sum(nil))
 	contentMD5Checksum := fmt.Sprintf("%x", contentMD5.Sum(nil))
@@ -157,7 +159,7 @@ func (f *FileResource) changeContentIfNeeded() (bool, error) {
 				fileMD5Checksum,
 			),
 		)
-		err := os.WriteFile(f.Data.Path, []byte(f.Data.Content), f.Data.Mode)
+		err := os.WriteFile(f.Data.Path, []byte(content), f.Data.Mode)
 		if err != nil {
 			return didSomething, err
 		}
@@ -180,7 +182,7 @@ func (f *FileResource) exist() bool {
 	return true
 }
 
-func (f *FileResource) create() error {
+func (f *FileResource) create(content string) error {
 	file, err := os.Create(f.Data.Path)
 	if err != nil {
 		return err
@@ -188,7 +190,7 @@ func (f *FileResource) create() error {
 	defer file.Close()
 
 	// Write content to file
-	file.Write([]byte(f.Data.Content))
+	file.Write([]byte(content))
 
 	// Change mode of file
 	file.Chmod(f.Data.Mode)
@@ -215,11 +217,23 @@ func (f *FileResource) delete() error {
 func (f *FileResource) Process(context *models.ResourceContext) (models.ResourceResult, error) {
 	var result models.ResourceResult
 
+	var fileContent string
+	var err error
+	if f.Data.Source != "" {
+		fileContent, err = context.ApiClient.RetrieveFile(f.Data.Source, context.Environment, f.Data.roleName)
+		if err != nil {
+			result.Failed = true
+			return result, err
+		}
+	} else {
+		fileContent = f.Data.Content
+	}
+
 	if !f.exist() && f.Present {
 		logrus.Info(
 			fmt.Sprintf("File (%s) does not exist, but should", f.Data.Path),
 		)
-		err := f.create()
+		err := f.create(fileContent)
 		if err != nil {
 			result.Failed = true
 			return result, err
@@ -249,7 +263,7 @@ func (f *FileResource) Process(context *models.ResourceContext) (models.Resource
 
 		// Check content of the file
 		var contentHasChanged bool
-		contentHasChanged, err = f.changeContentIfNeeded()
+		contentHasChanged, err = f.changeContentIfNeeded(fileContent)
 		if err != nil {
 			result.Failed = true
 			return result, err
@@ -309,6 +323,26 @@ func (f *FileResource) Validate() error {
 		}
 	}
 
+	if f.Data.Source != "" && f.Data.Content != "" {
+		validationErrors = append(
+			validationErrors,
+			models.ValidationError{
+				FieldName:    "content / source",
+				ViolatedRule: "content field and source field are mutually exclusive, you cannot use both.",
+			},
+		)
+	}
+
+	if f.Data.Source != "" && f.Data.roleName == "" {
+		validationErrors = append(
+			validationErrors,
+			models.ValidationError{
+				FieldName:    "source",
+				ViolatedRule: "source field cannot be used outside of roles",
+			},
+		)
+	}
+
 	if len(validationErrors) > 0 {
 		return models.ResourceValidationError{
 			Type:             f.Type,
@@ -320,7 +354,7 @@ func (f *FileResource) Validate() error {
 	return nil
 }
 
-func NewFileResource(resource *models.Resource, dataField any) (*FileResource, error) {
+func NewFileResource(resource *models.Resource, dataField any, roleContext *models.RoleContext) (*FileResource, error) {
 	var fileResource FileResource
 
 	// Define defaults value
@@ -351,6 +385,7 @@ func NewFileResource(resource *models.Resource, dataField any) (*FileResource, e
 	fileResource.WhenCondition = resource.When
 	fileResource.RegisterVariable = resource.Register
 	fileResource.Data = fileData
+	fileResource.Data.roleName = roleContext.RoleName
 
 	return &fileResource, nil
 }

--- a/pkg/resources/group/group.go
+++ b/pkg/resources/group/group.go
@@ -161,7 +161,7 @@ func (g *GroupResource) Validate() error {
 	return nil
 }
 
-func NewGroupResource(resource *models.Resource, dataField any) (*GroupResource, error) {
+func NewGroupResource(resource *models.Resource, dataField any, roleContext *models.RoleContext) (*GroupResource, error) {
 	var groupResource GroupResource
 
 	groupResource.Title = resource.Title

--- a/pkg/resources/group/group_test.go
+++ b/pkg/resources/group/group_test.go
@@ -20,7 +20,7 @@ func TestCreateAndDeleteGroup(t *testing.T) {
 		data := map[string]any{
 			"name": "peekl",
 		}
-		groupRes, err := NewGroupResource(&rawRes, data)
+		groupRes, err := NewGroupResource(&rawRes, data, nil)
 		if err != nil {
 			t.Errorf("No error should happen at that stage")
 		}
@@ -52,7 +52,7 @@ func TestCreateAndDeleteGroup(t *testing.T) {
 		data := map[string]any{
 			"name": "peekl",
 		}
-		groupRes, err := NewGroupResource(&rawRes, data)
+		groupRes, err := NewGroupResource(&rawRes, data, nil)
 		if err != nil {
 			t.Errorf("No error should happen at that stage")
 		}

--- a/pkg/resources/pkg/pkg.go
+++ b/pkg/resources/pkg/pkg.go
@@ -221,7 +221,7 @@ func (p *PackageResource) Validate() error {
 	return nil
 }
 
-func NewPackageResource(resource *models.Resource, dataField any) (*PackageResource, error) {
+func NewPackageResource(resource *models.Resource, dataField any, roleContext *models.RoleContext) (*PackageResource, error) {
 	var packageResource PackageResource
 
 	defaults := map[string]any{

--- a/pkg/resources/systemd_service/systemd_service.go
+++ b/pkg/resources/systemd_service/systemd_service.go
@@ -351,7 +351,7 @@ func (s *SystemdServiceResource) Validate() error {
 	return nil
 }
 
-func NewSystemdServiceResource(resource *models.Resource, dataField map[string]any) (*SystemdServiceResource, error) {
+func NewSystemdServiceResource(resource *models.Resource, dataField map[string]any, roleContext *models.RoleContext) (*SystemdServiceResource, error) {
 	var systemdServiceResource SystemdServiceResource
 
 	defaults := map[string]any{

--- a/pkg/resources/template/template.go
+++ b/pkg/resources/template/template.go
@@ -5,12 +5,12 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"io/fs"
 	"maps"
 	"os"
 	"syscall"
-	"text/template"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/peeklapp/peekl/pkg/facts"
@@ -21,15 +21,13 @@ import (
 )
 
 type TemplateData struct {
-	Name           string         `mapstructure:"name"`
-	Path           string         `mapstructure:"path"`
-	Owner          string         `mapstructure:"owner"`
-	Group          string         `mapstrucutre:"group"`
-	Mode           fs.FileMode    `mapstructure:"mode"`
-	Variables      map[string]any `mapstructure:"variables"`
-	rawTemplateDir string
-	rawTemplate    string
-	loadedTemplate template.Template
+	Name      string         `mapstructure:"name"`
+	Path      string         `mapstructure:"path"`
+	Owner     string         `mapstructure:"owner"`
+	Group     string         `mapstrucutre:"group"`
+	Mode      fs.FileMode    `mapstructure:"mode"`
+	Variables map[string]any `mapstructure:"variables"`
+	roleName  string
 }
 
 type TemplateResource struct {
@@ -132,7 +130,7 @@ func (t *TemplateResource) changeOwnershipIfNeeded() (bool, error) {
 	return didSomething, nil
 }
 
-func (t *TemplateResource) generateTemplate(ctx *models.ResourceContext) (string, error) {
+func (t *TemplateResource) generateTemplate(ctx *models.ResourceContext, templ *template.Template) (string, error) {
 	// Build facts map
 	factsMap := facts.FactsToMap(*ctx.Facts)
 
@@ -146,7 +144,7 @@ func (t *TemplateResource) generateTemplate(ctx *models.ResourceContext) (string
 
 	// Build actual template result from variables and template
 	var templateBytesResult bytes.Buffer
-	err := t.Data.loadedTemplate.ExecuteTemplate(&templateBytesResult, fmt.Sprintf("%s", t.Data.Name), variables)
+	err := templ.ExecuteTemplate(&templateBytesResult, fmt.Sprintf("%s", t.Data.Name), variables)
 	if err != nil {
 		return "", err
 	}
@@ -243,7 +241,19 @@ func (t *TemplateResource) changeContentIfNeeded(expectedContent string) (bool, 
 func (t *TemplateResource) Process(context *models.ResourceContext) (models.ResourceResult, error) {
 	var result models.ResourceResult
 
-	templateResult, err := t.generateTemplate(context)
+	rawTemplate, err := context.ApiClient.RetrieveTemplate(t.Data.Name, context.Environment, t.Data.roleName)
+	if err != nil {
+		result.Failed = true
+		return result, err
+	}
+
+	templ, err := template.New(t.Data.Name).Parse(rawTemplate)
+	if err != nil {
+		result.Failed = true
+		return result, err
+	}
+
+	templateResult, err := t.generateTemplate(context, templ)
 	if err != nil {
 		result.Failed = true
 		return result, err
@@ -353,8 +363,12 @@ func (t *TemplateResource) Validate() error {
 	return nil
 }
 
-func NewTemplateResource(resource *models.Resource, dataField map[string]any, templates map[string]string) (*TemplateResource, error) {
+func NewTemplateResource(resource *models.Resource, dataField map[string]any, roleContext *models.RoleContext) (*TemplateResource, error) {
 	var templateResource TemplateResource
+
+	if roleContext == nil {
+		return &templateResource, fmt.Errorf("Cannot use template resources outside of roles.")
+	}
 
 	defaults := map[string]any{
 		"owner": "root",
@@ -383,14 +397,7 @@ func NewTemplateResource(resource *models.Resource, dataField map[string]any, te
 	templateResource.WhenCondition = resource.When
 	templateResource.RegisterVariable = resource.Register
 	templateResource.Data = templateData
-
-	// Load raw template
-	currTemp := templates[templateData.Name]
-	rawTemplate, err := template.New(templateResource.Data.Name).Parse(currTemp)
-	if err != nil {
-		return &templateResource, err
-	}
-	templateResource.Data.loadedTemplate = *rawTemplate
+	templateResource.Data.roleName = roleContext.RoleName
 
 	// In the case that we didn't have any variables
 	if templateResource.Data.Variables == nil {

--- a/pkg/resources/user/user.go
+++ b/pkg/resources/user/user.go
@@ -384,7 +384,7 @@ func (u *UserResource) Validate() error {
 	return nil
 }
 
-func NewUserResource(resource *models.Resource, dataField any) (*UserResource, error) {
+func NewUserResource(resource *models.Resource, dataField any, roleContext *models.RoleContext) (*UserResource, error) {
 	var userResource UserResource
 
 	defaults := map[string]any{

--- a/pkg/resources/user/user_test.go
+++ b/pkg/resources/user/user_test.go
@@ -20,7 +20,7 @@ func TestCreateAndDeleteUser(t *testing.T) {
 		data := map[string]any{
 			"username": "max",
 		}
-		userRes, err := NewUserResource(&rawRes, data)
+		userRes, err := NewUserResource(&rawRes, data, nil)
 		if err != nil {
 			t.Errorf("No error should happen at that stage")
 		}
@@ -54,7 +54,7 @@ func TestCreateAndDeleteUser(t *testing.T) {
 		data := map[string]any{
 			"username": "max",
 		}
-		userRes, err := NewUserResource(&rawRes, data)
+		userRes, err := NewUserResource(&rawRes, data, nil)
 		if err != nil {
 			t.Errorf("No error should happen at that stage")
 		}

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/goccy/go-yaml"
@@ -12,29 +13,32 @@ import (
 	"github.com/peeklapp/peekl/pkg/variables"
 )
 
-func LoadRoleFromCode(codePath string, roleName string) (*models.Role, error) {
-	var role models.Role
-
-	// Set role name
-	role.Name = roleName
-
-	// Make sure template map is initilized
-	role.Templates = map[string]string{}
-
-	// Make sure to initialize map
-	role.IncludedResources = map[string]models.IncludedResources{}
-
-	// Make sure role exist locally
+func DoesRoleExist(codePath string, roleName string) error {
 	rolePath := filepath.Join(codePath, "roles", roleName)
 	if _, err := os.Stat(rolePath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return &role, models.RoleNotFoundError{RoleName: roleName}
+			return models.RoleNotFoundError{RoleName: roleName}
 		} else {
-			return &role, err
+			return err
 		}
+	}
+	return nil
+}
+
+func LoadRoleFromCode(codePath string, roleName string) (*models.Role, error) {
+	var role models.Role
+
+	role.Name = roleName
+	role.Templates = map[string]string{}
+	role.IncludedResources = map[string]models.IncludedResources{}
+
+	err := DoesRoleExist(codePath, roleName)
+	if err != nil {
+		return &role, err
 	}
 
 	// Open main.yml file, handle error if it does not exist
+	rolePath := filepath.Join(codePath, "roles", roleName)
 	mainFile, err := os.ReadFile(filepath.Join(rolePath, "main.yml"))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -120,4 +124,9 @@ func LoadRoleFromCode(codePath string, roleName string) (*models.Role, error) {
 	}
 
 	return &role, nil
+}
+
+func RoleNameIsValid(roleName string) bool {
+	r, _ := regexp.Compile("^[A-Za-z0-9_]+$")
+	return r.MatchString(roleName)
 }


### PR DESCRIPTION
Previously any templates that you wanted to get from the server, was going to be sent in the catalog when the agent would first require it. This is fine, but in the case of a lot of templates, this meant that the catalog would be very heavy.