### PR TITLE
fix(agent): improve logging for resources operations

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -50,7 +50,7 @@ func shouldNotSkipResource(res models.LoadedResource, resContext *models.Resourc
 
 func processResources(resources []models.LoadedResource, resContext *models.ResourceContext, catalogResult *CatalogResult) error {
 	for _, res := range resources {
-		logrus.Info(fmt.Sprintf("Processing resource [%s]", res.String()))
+		logrus.Info(fmt.Sprintf("[%s] Processing resource", res.String()))
 
 		// Process 'when' condition of resource
 		skip, err := shouldNotSkipResource(res, resContext)
@@ -58,13 +58,13 @@ func processResources(resources []models.LoadedResource, resContext *models.Reso
 			return err
 		}
 		if !skip {
-			logrus.Debug(fmt.Sprintf("Resource %s has been skipped", res.String()))
+			logrus.Debug(fmt.Sprintf("[%s] Resource has been skipped", res.String()))
 			catalogResult.Skipped = catalogResult.Skipped + 1
 			continue
 		}
 
 		// Output log for indication of resource finished being processed
-		finishedOutputLog := fmt.Sprintf("Finished processing of resource [%s]. Result: ", res.String())
+		finishedOutputLog := fmt.Sprintf("[%s] Finished processing, result: ", res.String())
 
 		// Process resource
 		result, err := res.Process(resContext)
@@ -165,7 +165,7 @@ func (c *Catalog) Process() error {
 	// Handle roles
 	if !failedResource {
 		for _, role := range c.roles {
-			logrus.Info(fmt.Sprintf("Processing role [%s]", role.Name))
+			logrus.Info(fmt.Sprintf("[%s] Process the role", role.Name))
 
 			// Handle main
 			err := processResources(role.LoadedResources, &resContext, &catalogResult)
@@ -181,7 +181,7 @@ func (c *Catalog) Process() error {
 						failedResource = true
 					}
 				}
-				logrus.Info(fmt.Sprintf("Finished processing role [%s]", role.Name))
+				logrus.Info(fmt.Sprintf("[%s] Finished processing role", role.Name))
 			}
 		}
 	}

--- a/pkg/resources/command/command.go
+++ b/pkg/resources/command/command.go
@@ -37,8 +37,9 @@ func (c *CommandResource) createsAlreadyExist() bool {
 func (c *CommandResource) Process(context *models.ResourceContext) (models.ResourceResult, error) {
 	var result models.ResourceResult
 
-	// If the path `creates` already exist we don't execute
+	logrus.Debug(fmt.Sprintf("[%s] Checking if the command needs to be ran, depending on if the `creates` path exist.", c.String()))
 	if c.createsAlreadyExist() {
+		logrus.Debug(fmt.Sprintf("[%s] The command does not need to be ran, as the `creates` path exist.", c.String()))
 		return result, nil
 	}
 
@@ -50,7 +51,7 @@ func (c *CommandResource) Process(context *models.ResourceContext) (models.Resou
 	cmd.Stdout = &stdoutBuff
 	cmd.Stderr = &stderrBuff
 
-	// Execute command
+	logrus.Debug(fmt.Sprintf("[%s] Running the command : %s", c.String(), commandWithArgs))
 	err := cmd.Run()
 
 	if err != nil {
@@ -62,19 +63,18 @@ func (c *CommandResource) Process(context *models.ResourceContext) (models.Resou
 					"stderr":    stderrBuff.String(),
 					"exit_code": exitError.ExitCode(),
 				},
-			).Error("Error during command execution")
+			).Error(fmt.Sprintf("[%s] Error during command execution", c.String()))
 			return result, nil
 		} else {
+			logrus.Debug(fmt.Sprintf("[%s] Command failed in an unexpected way.", c.String()))
 			return result, err
 		}
 	}
 
-	// Handle register of command output
 	if c.Data.RegisterOutput != "" {
 		context.Variables[c.Data.RegisterOutput] = stdoutBuff.String()
 	}
 
-	// Otherwise we consider the command succesful
 	result.Created = true
 	return result, nil
 }

--- a/pkg/resources/directory/directory.go
+++ b/pkg/resources/directory/directory.go
@@ -100,7 +100,8 @@ func (d *DirectoryResource) changeOwnershipIfNeeded() (bool, error) {
 
 		logrus.Info(
 			fmt.Sprintf(
-				"Ownership for directory (%s) should (%s:%s) but is (%s:%s)",
+				"[%s] Ownership for directory (%s) should (%s:%s) but is (%s:%s)",
+				d.String(),
 				d.Data.Path,
 				d.Data.Owner,
 				d.Data.Group,
@@ -112,7 +113,8 @@ func (d *DirectoryResource) changeOwnershipIfNeeded() (bool, error) {
 		didSomething = true
 		logrus.Info(
 			fmt.Sprintf(
-				"Ownership for directory (%s) updated from (%s:%s) to (%s:%s)",
+				"[%s] Ownership for directory (%s) updated from (%s:%s) to (%s:%s)",
+				d.String(),
 				d.Data.Path,
 				username,
 				groupName,
@@ -155,7 +157,7 @@ func (d *DirectoryResource) Process(context *models.ResourceContext) (models.Res
 
 	if !d.exist() && d.Present {
 		logrus.Info(
-			fmt.Sprintf("Directory (%s) does not exist, but should", d.Data.Path),
+			fmt.Sprintf("[%s] Directory (%s) does not exist, but should", d.String(), d.Data.Path),
 		)
 		err := d.create()
 		if err != nil {
@@ -163,12 +165,12 @@ func (d *DirectoryResource) Process(context *models.ResourceContext) (models.Res
 			return result, err
 		}
 		logrus.Info(
-			fmt.Sprintf("Directory (%s) created", d.Data.Path),
+			fmt.Sprintf("[%s] Directory (%s) created", d.String(), d.Data.Path),
 		)
 		result.Created = true
 	} else if d.exist() && !d.Present {
 		logrus.Info(
-			fmt.Sprintf("Directory (%s) exist, but should not", d.Data.Path),
+			fmt.Sprintf("[%s] Directory (%s) exist, but should not", d.String(), d.Data.Path),
 		)
 		err := d.delete()
 		if err != nil {
@@ -176,7 +178,7 @@ func (d *DirectoryResource) Process(context *models.ResourceContext) (models.Res
 			return result, err
 		}
 		logrus.Info(
-			fmt.Sprintf("Directory (%s) deleted", d.Data.Path),
+			fmt.Sprintf("[%s] Directory (%s) deleted", d.String(), d.Data.Path),
 		)
 		result.Deleted = true
 	}
@@ -185,14 +187,14 @@ func (d *DirectoryResource) Process(context *models.ResourceContext) (models.Res
 	if d.exist() && d.Present {
 		var err error
 
-		// Check permissions of the file
+		logrus.Debug(fmt.Sprintf("[%s] Checking permissions of the folder", d.String()))
 		permissionsHasBeenChanged, err := d.changePermissionsIfNeeded()
 		if err != nil {
 			result.Failed = true
 			return result, err
 		}
 
-		// Check owner/group of the file
+		logrus.Debug(fmt.Sprintf("[%s] Checking ownership of the folder", d.String()))
 		ownershipHasBeenChanged, err := d.changeOwnershipIfNeeded()
 		if err != nil {
 			result.Failed = true

--- a/pkg/resources/file/file.go
+++ b/pkg/resources/file/file.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"crypto/md5"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -138,25 +139,30 @@ func (f *FileResource) changeContentIfNeeded(content string) (bool, error) {
 	defer file.Close()
 
 	// Then we create MD5 object of file
-	fileMD5 := md5.New()
-	if _, err := io.Copy(fileMD5, file); err != nil {
+	localFileHasher := md5.New()
+	logrus.Debug(localFileHasher)
+
+	file.Seek(0, 0)
+	if _, err := io.Copy(localFileHasher, file); err != nil {
 		return didSomething, err
 	}
+	logrus.Debug(localFileHasher)
 
 	// Then we create MD5 object of content
-	contentMD5 := md5.New()
-	io.WriteString(contentMD5, content)
+	contentHasher := md5.New()
+	io.WriteString(contentHasher, content)
 
-	fileMD5Checksum := fmt.Sprintf("%x", fileMD5.Sum(nil))
-	contentMD5Checksum := fmt.Sprintf("%x", contentMD5.Sum(nil))
+	localFileMD5Value := hex.EncodeToString(localFileHasher.Sum(nil))
+	contentMD5Value := hex.EncodeToString(contentHasher.Sum(nil))
 
-	if fileMD5Checksum != contentMD5Checksum {
+	if localFileMD5Value != contentMD5Value {
 		logrus.Info(
 			fmt.Sprintf(
-				"Checksum for file (%s) should be (%s) but is (%s)",
+				"[%s] Checksum for file (%s) should be (%s) but is (%s)",
+				f.String(),
 				f.Data.Path,
-				contentMD5Checksum,
-				fileMD5Checksum,
+				contentMD5Value,
+				localFileMD5Value,
 			),
 		)
 		err := os.WriteFile(f.Data.Path, []byte(content), f.Data.Mode)
@@ -165,7 +171,8 @@ func (f *FileResource) changeContentIfNeeded(content string) (bool, error) {
 		}
 		logrus.Info(
 			fmt.Sprintf(
-				"File (%s) content has been updated",
+				"[%s] File (%s) content has been updated",
+				f.String(),
 				f.Data.Path,
 			),
 		)
@@ -231,7 +238,7 @@ func (f *FileResource) Process(context *models.ResourceContext) (models.Resource
 
 	if !f.exist() && f.Present {
 		logrus.Info(
-			fmt.Sprintf("File (%s) does not exist, but should", f.Data.Path),
+			fmt.Sprintf("[%s] File (%s) does not exist, but should", f.String(), f.Data.Path),
 		)
 		err := f.create(fileContent)
 		if err != nil {
@@ -239,12 +246,12 @@ func (f *FileResource) Process(context *models.ResourceContext) (models.Resource
 			return result, err
 		}
 		logrus.Info(
-			fmt.Sprintf("File (%s) created", f.Data.Path),
+			fmt.Sprintf("[%s] File (%s) created", f.String(), f.Data.Path),
 		)
 		result.Created = true
 	} else if f.exist() && !f.Present {
 		logrus.Info(
-			fmt.Sprintf("File (%s) exist, but should not", f.Data.Path),
+			fmt.Sprintf("[%s] File (%s) exist, but should not", f.String(), f.Data.Path),
 		)
 		err := f.delete()
 		if err != nil {
@@ -252,7 +259,7 @@ func (f *FileResource) Process(context *models.ResourceContext) (models.Resource
 			return result, err
 		}
 		logrus.Info(
-			fmt.Sprintf("File (%s) deleted", f.Data.Path),
+			fmt.Sprintf("[%s] File (%s) deleted", f.String(), f.Data.Path),
 		)
 		result.Deleted = true
 	}

--- a/pkg/resources/group/group.go
+++ b/pkg/resources/group/group.go
@@ -24,18 +24,19 @@ type GroupResource struct {
 func (g *GroupResource) exist() bool {
 	logrus.Debug(
 		fmt.Sprintf(
-			"Checking if group (%s) exist using the builtin Go package `os/user`",
+			"[%s] Checking if group (%s) exist using the builtin Go package `os/user`",
+			g.String(),
 			g.Data.Name,
 		),
 	)
 
 	_, err := user.LookupGroup(g.Data.Name)
 	if err != nil {
-		logrus.Debug(fmt.Sprintf("Group (%s) does not exist", g.Data.Name))
+		logrus.Debug(fmt.Sprintf("[%s] Group (%s) does not exist", g.String(), g.Data.Name))
 		return false
 	}
 
-	logrus.Debug(fmt.Sprintf("Group (%s) exist", g.Data.Name))
+	logrus.Debug(fmt.Sprintf("[%s] Group (%s) exist", g.String(), g.Data.Name))
 	return true
 }
 
@@ -45,7 +46,8 @@ func (g *GroupResource) create() error {
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Creating group (%s) using the following command : %s %s",
+			"[%s] Creating group (%s) using the following command : %s %s",
+			g.String(),
 			g.Data.Name,
 			command,
 			strings.Join(args, " "),
@@ -57,7 +59,7 @@ func (g *GroupResource) create() error {
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Debug("Could not execute command to create group")
+		}).Debug(fmt.Sprintf("[%s] Could not execute command to create group", g.String()))
 		return executionOutput.ErrorDetails
 	}
 
@@ -70,7 +72,8 @@ func (g *GroupResource) delete() error {
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Deleting group (%s) using the following command : %s %s",
+			"[%s] Deleting group (%s) using the following command : %s %s",
+			g.String(),
 			g.Data.Name,
 			command,
 			strings.Join(args, " "),
@@ -82,7 +85,7 @@ func (g *GroupResource) delete() error {
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Debug("Could not execute command to delete group")
+		}).Debug(fmt.Sprintf("[%s] Could not execute command to delete group", g.String()))
 		return executionOutput.ErrorDetails
 	}
 
@@ -96,26 +99,26 @@ func (g *GroupResource) Process(context *models.ResourceContext) (models.Resourc
 
 	if !exist && g.Present {
 		logrus.Info(
-			fmt.Sprintf("Group (%s) does not exist but should", g.Data.Name),
+			fmt.Sprintf("[%s] Group (%s) does not exist but should", g.String(), g.Data.Name),
 		)
 		err := g.create()
 		if err != nil {
 			return result, err
 		}
 		logrus.Info(
-			fmt.Sprintf("Group (%s) created", g.Data.Name),
+			fmt.Sprintf("[%s] Group (%s) created", g.String(), g.Data.Name),
 		)
 		result.Created = true
 	} else if exist && !g.Present {
 		logrus.Info(
-			fmt.Sprintf("Group (%s) exist but should not", g.Data.Name),
+			fmt.Sprintf("[%s] Group (%s) exist but should not", g.String(), g.Data.Name),
 		)
 		err := g.delete()
 		if err != nil {
 			return result, err
 		}
 		logrus.Info(
-			fmt.Sprintf("Group (%s) deleted", g.Data.Name),
+			fmt.Sprintf("[%s] Group (%s) deleted", g.String(), g.Data.Name),
 		)
 		result.Deleted = true
 	}

--- a/pkg/resources/pkg/pkg.go
+++ b/pkg/resources/pkg/pkg.go
@@ -95,7 +95,8 @@ func (p *PackageResource) Process(context *models.ResourceContext) (models.Resou
 		if len(nonInstalledPackagesThatShouldBe) != 0 {
 			logrus.Info(
 				fmt.Sprintf(
-					"Packages (%s) are not installed but should be",
+					"[%s] Packages (%s) are not installed but should be",
+					p.String(),
 					strings.Join(nonInstalledPackagesThatShouldBeNames, " "),
 				),
 			)
@@ -107,7 +108,8 @@ func (p *PackageResource) Process(context *models.ResourceContext) (models.Resou
 			result.Created = true
 			logrus.Info(
 				fmt.Sprintf(
-					"Packages (%s) have been installed",
+					"[%s] Packages (%s) have been installed",
+					p.String(),
 					strings.Join(nonInstalledPackagesThatShouldBeNames, " "),
 				),
 			)
@@ -134,7 +136,8 @@ func (p *PackageResource) Process(context *models.ResourceContext) (models.Resou
 			// Install packages with correct versions
 			logrus.Info(
 				fmt.Sprintf(
-					"Packages (%s) does not have the correct version",
+					"[%s] Packages (%s) does not have the correct version",
+					p.String(),
 					strings.Join(packagesWithWrongVersionNames, " "),
 				),
 			)
@@ -145,7 +148,8 @@ func (p *PackageResource) Process(context *models.ResourceContext) (models.Resou
 			}
 			logrus.Info(
 				fmt.Sprintf(
-					"Packages (%s) versions have been updated",
+					"[%s] Packages (%s) versions have been updated",
+					p.String(),
 					strings.Join(packagesWithWrongVersionNames, " "),
 				),
 			)
@@ -155,7 +159,7 @@ func (p *PackageResource) Process(context *models.ResourceContext) (models.Resou
 		if len(installedPackagesThatShouldNot) != 0 {
 			for _, pkg := range installedPackagesThatShouldNot {
 				logrus.Info(
-					fmt.Sprintf("Package (%s) is installed but should not", pkg.Name),
+					fmt.Sprintf("[%s] Package (%s) is installed but should not", p.String(), pkg.Name),
 				)
 			}
 			err := p.Data.installer.Remove(installedPackagesThatShouldNot)
@@ -166,7 +170,7 @@ func (p *PackageResource) Process(context *models.ResourceContext) (models.Resou
 			result.Deleted = true
 			for _, pkg := range installedPackagesThatShouldNot {
 				logrus.Info(
-					fmt.Sprintf("Package (%s) has been removed", pkg.Name),
+					fmt.Sprintf("[%s] Package (%s) has been removed", p.String(), pkg.Name),
 				)
 			}
 		}

--- a/pkg/resources/systemd_service/systemd_service.go
+++ b/pkg/resources/systemd_service/systemd_service.go
@@ -37,7 +37,7 @@ func (s *SystemdServiceResource) checkIfServiceIsEnabledOrMasked(checking string
 	case "masked":
 		break
 	default:
-		return false, fmt.Errorf("You can only checked for enabled of for masked")
+		return false, fmt.Errorf("[%s] You can only checked for enabled of for masked", s.String())
 	}
 
 	command := "systemctl"
@@ -45,7 +45,8 @@ func (s *SystemdServiceResource) checkIfServiceIsEnabledOrMasked(checking string
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Checking if service is %s using the following command : %s %s",
+			"[%s] Checking if service is %s using the following command : %s %s",
+			s.String(),
 			checking,
 			command,
 			strings.Join(args, " "),
@@ -58,7 +59,7 @@ func (s *SystemdServiceResource) checkIfServiceIsEnabledOrMasked(checking string
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Debug("Could not execute command to verify if a service is enabled")
+		}).Debug(fmt.Sprintf("[%s] Could not execute command to verify if a service is enabled", s.String()))
 		return false, executionOutput.ErrorDetails
 	}
 
@@ -74,7 +75,8 @@ func (s *SystemdServiceResource) getServiceDetails() (map[string]string, error) 
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Getting details of a systemd service using the following command : %s %s",
+			"[%s] Getting details of a systemd service using the following command : %s %s",
+			s.String(),
 			command,
 			strings.Join(args, " "),
 		),
@@ -86,7 +88,7 @@ func (s *SystemdServiceResource) getServiceDetails() (map[string]string, error) 
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Debug("Could not execute command to get service details")
+		}).Debug(fmt.Sprintf("[%s] Could not execute command to get service details", s.String()))
 		return nil, executionOutput.ErrorDetails
 	}
 
@@ -129,7 +131,8 @@ func (s *SystemdServiceResource) doActionOnService(action string) error {
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Performing action (%s) on service (%s.service) with following command : %s %s",
+			"[%s] Performing action (%s) on service (%s.service) with following command : %s %s",
+			s.String(),
 			action,
 			s.Data.Name,
 			command,
@@ -143,7 +146,7 @@ func (s *SystemdServiceResource) doActionOnService(action string) error {
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Debug("Could not execute command to perform action on service")
+		}).Debug(fmt.Sprintf("[%s] Could not execute command to perform action on service", s.String()))
 		return executionOutput.ErrorDetails
 	}
 
@@ -189,7 +192,7 @@ func (s *SystemdServiceResource) Process(context *models.ResourceContext) (model
 		// Check if the service active state is considered running
 		if !slices.Contains(acceptableRunningStates, serviceDetails["ActiveState"]) {
 			logrus.Info(
-				fmt.Sprintf("Service (%s.service) is not running but should", s.Data.Name),
+				fmt.Sprintf("[%s] Service (%s.service) is not running but should", s.String(), s.Data.Name),
 			)
 			// Start the service
 			err := s.doActionOnService("start")
@@ -199,13 +202,13 @@ func (s *SystemdServiceResource) Process(context *models.ResourceContext) (model
 			}
 			result.Updated = true
 			logrus.Info(
-				fmt.Sprintf("Service (%s.service) started", s.Data.Name),
+				fmt.Sprintf("[%s] Service (%s.service) started", s.String(), s.Data.Name),
 			)
 		}
 	case "stopped":
 		if slices.Contains(acceptableRunningStates, serviceDetails["ActiveState"]) && serviceDetails["ActiveState"] != "deactivating" {
 			logrus.Info(
-				fmt.Sprintf("Service (%s.service) is running but should not", s.Data.Name),
+				fmt.Sprintf("[%s] Service (%s.service) is running but should not", s.String(), s.Data.Name),
 			)
 			// Stop the service
 			err := s.doActionOnService("stop")
@@ -215,7 +218,7 @@ func (s *SystemdServiceResource) Process(context *models.ResourceContext) (model
 			}
 			result.Updated = true
 			logrus.Info(
-				fmt.Sprintf("Service (%s.service) stopped", s.Data.Name),
+				fmt.Sprintf("[%s] Service (%s.service) stopped", s.String(), s.Data.Name),
 			)
 		}
 	case "restarted":
@@ -223,7 +226,7 @@ func (s *SystemdServiceResource) Process(context *models.ResourceContext) (model
 		// to bother for any previous status of the service,
 		// we simply send a restart action to the service
 		logrus.Info(
-			fmt.Sprintf("Service (%s.service) should be restarted", s.Data.Name),
+			fmt.Sprintf("[%s] Service (%s.service) should be restarted", s.String(), s.Data.Name),
 		)
 		err := s.doActionOnService("restart")
 		if err != nil {
@@ -232,11 +235,11 @@ func (s *SystemdServiceResource) Process(context *models.ResourceContext) (model
 		}
 		result.Updated = true
 		logrus.Info(
-			fmt.Sprintf("Service (%s.service) restarted", s.Data.Name),
+			fmt.Sprintf("[%s] Service (%s.service) restarted", s.String(), s.Data.Name),
 		)
 	case "reloaded":
 		logrus.Info(
-			fmt.Sprintf("Service (%s.service) should be reloaded", s.Data.Name),
+			fmt.Sprintf("[%s] Service (%s.service) should be reloaded", s.String(), s.Data.Name),
 		)
 		err := s.doActionOnService("reload")
 		if err != nil {
@@ -245,7 +248,7 @@ func (s *SystemdServiceResource) Process(context *models.ResourceContext) (model
 		}
 		result.Updated = true
 		logrus.Info(
-			fmt.Sprintf("Service (%s.service) reloaded", s.Data.Name),
+			fmt.Sprintf("[%s] Service (%s.service) reloaded", s.String(), s.Data.Name),
 		)
 	}
 
@@ -258,7 +261,7 @@ func (s *SystemdServiceResource) Process(context *models.ResourceContext) (model
 	if enabled != s.Data.Enabled {
 		if s.Data.Enabled {
 			logrus.Info(
-				fmt.Sprintf("Service (%s.service) is not enabled but should", s.Data.Name),
+				fmt.Sprintf("[%s] Service (%s.service) is not enabled but should", s.String(), s.Data.Name),
 			)
 			err := s.doActionOnService("enable")
 			if err != nil {
@@ -267,11 +270,11 @@ func (s *SystemdServiceResource) Process(context *models.ResourceContext) (model
 			}
 			result.Updated = true
 			logrus.Info(
-				fmt.Sprintf("Service (%s.service) enabled", s.Data.Name),
+				fmt.Sprintf("[%s] Service (%s.service) enabled", s.String(), s.Data.Name),
 			)
 		} else {
 			logrus.Info(
-				fmt.Sprintf("Service (%s.service) enabled but should not", s.Data.Name),
+				fmt.Sprintf("[%s] Service (%s.service) enabled but should not", s.String(), s.Data.Name),
 			)
 			err := s.doActionOnService("disable")
 			if err != nil {
@@ -280,7 +283,7 @@ func (s *SystemdServiceResource) Process(context *models.ResourceContext) (model
 			}
 			result.Updated = true
 			logrus.Info(
-				fmt.Sprintf("Service (%s.service) disabled", s.Data.Name),
+				fmt.Sprintf("[%s] Service (%s.service) disabled", s.String(), s.Data.Name),
 			)
 		}
 	}

--- a/pkg/resources/template/template.go
+++ b/pkg/resources/template/template.go
@@ -48,7 +48,8 @@ func (t *TemplateResource) changePermissionsIfNeeded() (bool, error) {
 	if stat.Mode() != t.Data.Mode {
 		logrus.Info(
 			fmt.Sprintf(
-				"Mode for the template file (%s) should be (%s) but is (%s)",
+				"[%s] Mode for the template file (%s) should be (%s) but is (%s)",
+				t.String(),
 				t.Data.Path,
 				t.Data.Mode,
 				stat.Mode(),
@@ -58,7 +59,8 @@ func (t *TemplateResource) changePermissionsIfNeeded() (bool, error) {
 		didSomething = true
 		logrus.Info(
 			fmt.Sprintf(
-				"Mode for the template file (%s) has been updated from (%s) to (%s)",
+				"[%s] Mode for the template file (%s) has been updated from (%s) to (%s)",
+				t.String(),
 				t.Data.Path,
 				stat.Mode(),
 				t.Data.Mode,
@@ -106,7 +108,8 @@ func (t *TemplateResource) changeOwnershipIfNeeded() (bool, error) {
 
 		logrus.Info(
 			fmt.Sprintf(
-				"Ownership of the template file (%s) should be (%s:%s) but is (%s:%s)",
+				"[%s] Ownership of the template file (%s) should be (%s:%s) but is (%s:%s)",
+				t.String(),
 				t.Data.Path,
 				t.Data.Owner,
 				t.Data.Group,
@@ -118,7 +121,8 @@ func (t *TemplateResource) changeOwnershipIfNeeded() (bool, error) {
 		didSomething = true
 		logrus.Info(
 			fmt.Sprintf(
-				"Ownership of the template file (%s) updated from (%s:%s) to (%s:%s)",
+				"[%s] Ownership of the template file (%s) updated from (%s:%s) to (%s:%s)",
+				t.String(),
 				t.Data.Path,
 				username,
 				groupName,
@@ -217,7 +221,8 @@ func (t *TemplateResource) changeContentIfNeeded(expectedContent string) (bool, 
 	if fileMD5Checksum != contentMD5Checksum {
 		logrus.Info(
 			fmt.Sprintf(
-				"Checksum for file (%s) should be (%s) but is (%s)",
+				"[%s] Checksum for file (%s) should be (%s) but is (%s)",
+				t.String(),
 				t.Data.Path,
 				contentMD5Checksum,
 				fileMD5Checksum,
@@ -229,7 +234,8 @@ func (t *TemplateResource) changeContentIfNeeded(expectedContent string) (bool, 
 		}
 		logrus.Info(
 			fmt.Sprintf(
-				"File (%s) content has been updated",
+				"[%s] File (%s) content has been updated",
+				t.String(),
 				t.Data.Path,
 			),
 		)
@@ -261,7 +267,7 @@ func (t *TemplateResource) Process(context *models.ResourceContext) (models.Reso
 
 	if !t.exist() && t.Present {
 		logrus.Info(
-			fmt.Sprintf("Template file (%s) does not exist, but should", t.Data.Path),
+			fmt.Sprintf("[%s] Template file (%s) does not exist, but should", t.String(), t.Data.Path),
 		)
 		err := t.create(templateResult)
 		if err != nil {
@@ -269,12 +275,12 @@ func (t *TemplateResource) Process(context *models.ResourceContext) (models.Reso
 			return result, err
 		}
 		logrus.Info(
-			fmt.Sprintf("Temaplte file (%s) created", t.Data.Path),
+			fmt.Sprintf("[%s] Template file (%s) created", t.String(), t.Data.Path),
 		)
 		result.Created = true
 	} else if t.exist() && !t.Present {
 		logrus.Info(
-			fmt.Sprintf("Template file (%s) exist, but should not", t.Data.Path),
+			fmt.Sprintf("[%s] Template file (%s) exist, but should not", t.String(), t.Data.Path),
 		)
 		err := t.delete()
 		if err != nil {
@@ -282,7 +288,7 @@ func (t *TemplateResource) Process(context *models.ResourceContext) (models.Reso
 			return result, err
 		}
 		logrus.Info(
-			fmt.Sprintf("Template file (%s) deleted", t.Data.Path),
+			fmt.Sprintf("[%s] Template file (%s) deleted", t.String(), t.Data.Path),
 		)
 		result.Deleted = true
 	}

--- a/pkg/resources/user/user.go
+++ b/pkg/resources/user/user.go
@@ -30,18 +30,19 @@ type UserResource struct {
 func (u *UserResource) exist() bool {
 	logrus.Debug(
 		fmt.Sprintf(
-			"Checking if user (%s) exist using builtin Go package `os/user`",
+			"[%s] Checking if user (%s) exist using builtin Go package `os/user`",
+			u.String(),
 			u.Data.Username,
 		),
 	)
 
 	_, err := user.Lookup(u.Data.Username)
 	if err != nil {
-		logrus.Debug(fmt.Sprintf("User (%s) does not exist", u.Data.Username))
+		logrus.Debug(fmt.Sprintf("[%s] User (%s) does not exist", u.String(), u.Data.Username))
 		return false
 	}
 
-	logrus.Debug(fmt.Sprintf("User (%s) exist", u.Data.Username))
+	logrus.Debug(fmt.Sprintf("[%s] User (%s) exist", u.String(), u.Data.Username))
 	return true
 }
 
@@ -53,7 +54,8 @@ func (u *UserResource) getCurrentGroups() ([]string, error) {
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Getting user (%s) group using the following command : %s %s",
+			"[%s] Getting user (%s) group using the following command : %s %s",
+			u.String(),
 			u.Data.Username,
 			command,
 			strings.Join(args, " "),
@@ -66,7 +68,7 @@ func (u *UserResource) getCurrentGroups() ([]string, error) {
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Debug("Could not execute command to get user shell")
+		}).Debug(fmt.Sprintf("[%s] Could not execute command to get user shell", u.String()))
 		return groups, executionOutput.ErrorDetails
 	}
 
@@ -83,7 +85,8 @@ func (u *UserResource) addToGroup(group string) error {
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Adding user (%s) to group (%s) using the following command : %s %s",
+			"[%s] Adding user (%s) to group (%s) using the following command : %s %s",
+			u.String(),
 			u.Data.Username,
 			group,
 			command,
@@ -97,7 +100,7 @@ func (u *UserResource) addToGroup(group string) error {
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Debug("")
+		}).Debug(fmt.Sprintf("[%s] Error while trying to add user to group", u.String()))
 		return executionOutput.ErrorDetails
 	}
 
@@ -116,7 +119,8 @@ func (u *UserResource) addUserToGroupsIfNeeded() (bool, error) {
 		if !slices.Contains(groups, group) {
 			logrus.Info(
 				fmt.Sprintf(
-					"User (%s) is not a member of group (%s) but should be",
+					"[%s] User (%s) is not a member of group (%s) but should be",
+					u.String(),
 					u.Data.Username,
 					group,
 				),
@@ -127,7 +131,8 @@ func (u *UserResource) addUserToGroupsIfNeeded() (bool, error) {
 			}
 			logrus.Info(
 				fmt.Sprintf(
-					"User (%s) added to group (%s)",
+					"[%s] User (%s) added to group (%s)",
+					u.String(),
 					u.Data.Username,
 					group,
 				),
@@ -145,7 +150,8 @@ func (u *UserResource) getCurrentShell() (string, error) {
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Getting user (%s) shell using the following command : %s %s",
+			"[%s] Getting user (%s) shell using the following command : %s %s",
+			u.String(),
 			u.Data.Username,
 			command,
 			strings.Join(args, " "),
@@ -158,14 +164,14 @@ func (u *UserResource) getCurrentShell() (string, error) {
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Debug("Could not execute command to get user shell")
+		}).Debug(fmt.Sprintf("[%s] Could not execute command to get user shell", u.String()))
 		return "", executionOutput.ErrorDetails
 	}
 
 	shell := strings.Trim(strings.Split(executionOutput.Stdout, ":")[6], "\n")
 
 	logrus.Debug(
-		fmt.Sprintf("Found shell (%s) for user (%s)", shell, u.Data.Username),
+		fmt.Sprintf("[%s] Found shell (%s) for user (%s)", shell, u.String(), u.Data.Username),
 	)
 	return shell, nil
 }
@@ -176,7 +182,8 @@ func (u *UserResource) setShell() error {
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Updating user (%s) shell using the following command : %s %s",
+			"[%s] Updating user (%s) shell using the following command : %s %s",
+			u.String(),
 			u.Data.Username,
 			command,
 			strings.Join(args, " "),
@@ -189,7 +196,7 @@ func (u *UserResource) setShell() error {
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Debug("Could not execute command to change user shell")
+		}).Debug(fmt.Sprintf("[%s] Could not execute command to change user shell", u.String()))
 		return executionOutput.ErrorDetails
 	}
 
@@ -207,7 +214,8 @@ func (u *UserResource) updateShellIfNeeded() (bool, error) {
 	if userShell != u.Data.Shell {
 		logrus.Info(
 			fmt.Sprintf(
-				"Shell for user (%s) should be (%s) but is (%s)",
+				"[%s] Shell for user (%s) should be (%s) but is (%s)",
+				u.String(),
 				u.Data.Username,
 				u.Data.Shell,
 				userShell,
@@ -219,7 +227,8 @@ func (u *UserResource) updateShellIfNeeded() (bool, error) {
 		}
 		logrus.Info(
 			fmt.Sprintf(
-				"Shell for user (%s) has been updated from (%s) to (%s)",
+				"[%s] Shell for user (%s) has been updated from (%s) to (%s)",
+				u.String(),
 				u.Data.Username,
 				userShell,
 				u.Data.Shell,
@@ -246,7 +255,8 @@ func (u *UserResource) create() error {
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Creating user (%s) using the following command : %s %s",
+			"[%s] Creating user (%s) using the following command : %s %s",
+			u.String(),
 			u.Data.Username,
 			command,
 			strings.Join(args, " "),
@@ -259,7 +269,7 @@ func (u *UserResource) create() error {
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Info("Could not execute command to create user")
+		}).Info(fmt.Sprintf("[%s] Could not execute command to create user", u.String()))
 		return executionOutput.ErrorDetails
 	}
 	return nil
@@ -271,7 +281,8 @@ func (u *UserResource) delete() error {
 
 	logrus.Debug(
 		fmt.Sprintf(
-			"Deleting user (%s) using the following command : %s %s",
+			"[%s] Deleting user (%s) using the following command : %s %s",
+			u.String(),
 			u.Data.Username,
 			command,
 			strings.Join(args, " "),
@@ -284,7 +295,7 @@ func (u *UserResource) delete() error {
 			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
 			"stderr":    executionOutput.ErrorDetails.Stderr,
 			"exit_code": executionOutput.ErrorDetails.ExitCode,
-		}).Debug("Could not execute command to delete user")
+		}).Debug(fmt.Sprintf("[%s] Could not execute command to delete user", u.String()))
 		return executionOutput.ErrorDetails
 	}
 	return nil
@@ -296,7 +307,7 @@ func (u *UserResource) Process(context *models.ResourceContext) (models.Resource
 	// Handle user creation of deletion if needed
 	if !u.exist() && u.Present {
 		logrus.Info(
-			fmt.Sprintf("User (%s) does not exist but should", u.Data.Username),
+			fmt.Sprintf("[%s] User (%s) does not exist but should", u.String(), u.Data.Username),
 		)
 		err := u.create()
 		if err != nil {
@@ -304,12 +315,12 @@ func (u *UserResource) Process(context *models.ResourceContext) (models.Resource
 			return result, err
 		}
 		logrus.Info(
-			fmt.Sprintf("User (%s) created", u.Data.Username),
+			fmt.Sprintf("[%s] User (%s) created", u.String(), u.Data.Username),
 		)
 		result.Created = true
 	} else if u.exist() && !u.Present {
 		logrus.Info(
-			fmt.Sprintf("User (%s) exist but should not", u.Data.Username),
+			fmt.Sprintf("[%s] User (%s) exist but should not", u.String(), u.Data.Username),
 		)
 		err := u.delete()
 		if err != nil {
@@ -317,7 +328,7 @@ func (u *UserResource) Process(context *models.ResourceContext) (models.Resource
 			return result, err
 		}
 		logrus.Info(
-			fmt.Sprintf("User (%s) deleted", u.Data.Username),
+			fmt.Sprintf("[%s] User (%s) deleted", u.String(), u.Data.Username),
 		)
 		result.Deleted = true
 	}


### PR DESCRIPTION
This commit make sure that it's easier to see what's happening when resources are being processed on the agent side. Previsouly it was a little bit messy, and you didn't really knew which log belong to which resource.