### PR TITLE
fix: remove OsFacts from facts

### DIFF
--- a/pkg/models/facts.go
+++ b/pkg/models/facts.go
@@ -1,10 +1,5 @@
 package models
 
-type OsFacts struct {
-	Arch   string `json:"arch"`
-	Distro string `json:"distro"`
-}
-
 type PackageFact struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
@@ -89,7 +84,6 @@ type Disk struct {
 
 type Facts struct {
 	Hostname          string             `json:"hostname"`
-	Os                OsFacts            `json:"os"`
 	Packages          []Package          `json:"packages"`
 	NetworkInterfaces []NetworkInterface `json:"network_interfaces"`
 	Lsb               LsbData            `json:"lsb"`


### PR DESCRIPTION
This commit removes any OsFacts reference as it's not used anymore and has been replaced by LSB facts which allows you to get the same kind of informations.