### PR TITLE
feat: add `builtin.systemd_daemon` resource

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -13,6 +13,7 @@ import (
 	"github.com/peeklapp/peekl/pkg/resources/file"
 	"github.com/peeklapp/peekl/pkg/resources/group"
 	"github.com/peeklapp/peekl/pkg/resources/pkg"
+	systemdDaemon "github.com/peeklapp/peekl/pkg/resources/systemd_daemon"
 	"github.com/peeklapp/peekl/pkg/resources/systemd_service"
 	"github.com/peeklapp/peekl/pkg/resources/template"
 	"github.com/peeklapp/peekl/pkg/resources/user"
@@ -270,59 +271,25 @@ func (c *Catalog) loadSingleResource(resource models.Resource, dataField map[str
 
 	switch resource.Type {
 	case "builtin.user":
-		loadedUser, err := user.NewUserResource(&resource, dataField, roleContext)
-		if err != nil {
-			return nil, err
-		}
-		return loadedUser, nil
+		return user.NewUserResource(&resource, dataField, roleContext)
 	case "builtin.group":
-		loadedGroup, err := group.NewGroupResource(&resource, dataField, roleContext)
-		if err != nil {
-			return nil, err
-		}
-		return loadedGroup, nil
+		return group.NewGroupResource(&resource, dataField, roleContext)
 	case "builtin.file":
-		loadedFile, err := file.NewFileResource(&resource, dataField, roleContext)
-		if err != nil {
-			return nil, err
-		}
-		return loadedFile, nil
+		return file.NewFileResource(&resource, dataField, roleContext)
 	case "builtin.directory":
-		loadedDirectory, err := directory.NewDirectoryResource(&resource, dataField, roleContext)
-		if err != nil {
-			return nil, err
-		}
-		return loadedDirectory, nil
+		return directory.NewDirectoryResource(&resource, dataField, roleContext)
 	case "builtin.pkg":
-		loadedPkg, err := pkg.NewPackageResource(&resource, dataField, roleContext)
-		if err != nil {
-			return nil, err
-		}
-		return loadedPkg, nil
+		return pkg.NewPackageResource(&resource, dataField, roleContext)
 	case "builtin.template":
-		loadedTemplate, err := template.NewTemplateResource(&resource, dataField, roleContext)
-		if err != nil {
-			return nil, err
-		}
-		return loadedTemplate, nil
+		return template.NewTemplateResource(&resource, dataField, roleContext)
 	case "builtin.systemd_service":
-		loadedSystemdService, err := systemdservice.NewSystemdServiceResource(&resource, dataField, roleContext)
-		if err != nil {
-			return nil, err
-		}
-		return loadedSystemdService, nil
+		return systemdService.NewSystemdServiceResource(&resource, dataField, roleContext)
+	case "builtin.systemd_daemon":
+		return systemdDaemon.NewSystemdDaemonResource(&resource, dataField, roleContext)
 	case "builtin.debug":
-		loadedDebug, err := debug.NewDebugResource(&resource, dataField, roleContext)
-		if err != nil {
-			return nil, err
-		}
-		return loadedDebug, nil
+		return debug.NewDebugResource(&resource, dataField, roleContext)
 	case "builtin.command":
-		loadedCommand, err := command.NewCommandResource(&resource, dataField, roleContext)
-		if err != nil {
-			return nil, err
-		}
-		return loadedCommand, nil
+		return command.NewCommandResource(&resource, dataField, roleContext)
 	}
 	return nil, fmt.Errorf("Unknown resource type : %s", resource.Type)
 }

--- a/pkg/resources/systemd_daemon/systemd_daemon.go
+++ b/pkg/resources/systemd_daemon/systemd_daemon.go
@@ -1,0 +1,95 @@
+package systemd_daemon
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/peeklapp/peekl/pkg/models"
+	"github.com/peeklapp/peekl/pkg/resources"
+	"github.com/peeklapp/peekl/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+type SystemdDaemonData struct {
+	Reload bool `mapstructure:"reload"`
+}
+
+type SystemdDaemonResource struct {
+	resources.CommonFieldResource
+	Data SystemdDaemonData
+}
+
+func (s *SystemdDaemonResource) reloadSystemdDaemon() error {
+	command := "systemctl"
+	args := []string{"daemon-reload"}
+
+	logrus.Debug(
+		fmt.Sprintf(
+			"[%s] Reload systemd daemon using the following command : %s %s",
+			s.String(),
+			command,
+			strings.Join(args, " "),
+		),
+	)
+
+	executionOutput := utils.Execute(command, args...)
+	if executionOutput.ErrorDetails.ExitCode != 0 {
+		logrus.WithFields(logrus.Fields{
+			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
+			"stderr":    executionOutput.ErrorDetails.Stderr,
+			"exit_code": executionOutput.ErrorDetails.ExitCode,
+		}).Debug(fmt.Sprintf("[%s] Could not execute command to reload systemd daemon.", s.String()))
+		return executionOutput.ErrorDetails
+	}
+
+	return nil
+}
+
+func (s *SystemdDaemonResource) Process(context *models.ResourceContext) (models.ResourceResult, error) {
+	var result models.ResourceResult
+
+	if s.Data.Reload {
+		err := s.reloadSystemdDaemon()
+		if err != nil {
+			result.Failed = true
+			return result, err
+		}
+	}
+
+	return result, nil
+}
+
+func (s *SystemdDaemonResource) String() string {
+	return fmt.Sprintf("%s / '%s'", s.Type, s.Title)
+}
+
+func (s *SystemdDaemonResource) When() string {
+	return s.WhenCondition
+}
+
+func (s *SystemdDaemonResource) Register() string {
+	return s.RegisterVariable
+}
+
+func (s *SystemdDaemonResource) Validate() error {
+	// Not that much to validate in this case
+	return nil
+}
+
+func NewSystemdDaemonResource(resource *models.Resource, dataField any, roleContext *models.RoleContext) (*SystemdDaemonResource, error) {
+	var systemdDaemonResource SystemdDaemonResource
+
+	systemdDaemonResource.Title = resource.Title
+	systemdDaemonResource.Type = resource.Type
+	systemdDaemonResource.Present = *resource.Present
+	systemdDaemonResource.WhenCondition = resource.When
+	systemdDaemonResource.RegisterVariable = resource.Register
+
+	err := mapstructure.Decode(dataField, &systemdDaemonResource.Data)
+	if err != nil {
+		return &systemdDaemonResource, err
+	}
+
+	return &systemdDaemonResource, nil
+}

--- a/pkg/resources/systemd_daemon/systemd_daemon.go
+++ b/pkg/resources/systemd_daemon/systemd_daemon.go
@@ -1,4 +1,4 @@
-package systemd_daemon
+package systemdDaemon
 
 import (
 	"fmt"

--- a/pkg/resources/systemd_daemon/systemd_daemon.go
+++ b/pkg/resources/systemd_daemon/systemd_daemon.go
@@ -50,11 +50,24 @@ func (s *SystemdDaemonResource) Process(context *models.ResourceContext) (models
 	var result models.ResourceResult
 
 	if s.Data.Reload {
+		logrus.Info(
+			fmt.Sprintf(
+				"[%s] Systemd daemon should be reloaded",
+				s.String(),
+			),
+		)
 		err := s.reloadSystemdDaemon()
 		if err != nil {
 			result.Failed = true
 			return result, err
 		}
+		result.Updated = true
+		logrus.Info(
+			fmt.Sprintf(
+				"[%s] Systemd daemon has been reloaded",
+				s.String(),
+			),
+		)
 	}
 
 	return result, nil

--- a/pkg/resources/systemd_service/systemd_service.go
+++ b/pkg/resources/systemd_service/systemd_service.go
@@ -1,4 +1,4 @@
-package systemdservice
+package systemdService
 
 import (
 	"fmt"


### PR DESCRIPTION
This commit add the `builtin.systemd_daemon` resource in order to allow the user to reload the systemd daemon. It might get expanded in the future with more options.