### PR TITLE
feat(peekl-code): initial release of cli-tool peekl-code

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,14 +45,30 @@ builds:
       - -X github.com/peeklapp/peekl/cmd/server/commands.commit={{.Commit}}
       - -X github.com/peeklapp/peekl/cmd/server/commands.date={{.CommitDate}}
 
+  - id: code
+    binary: peekl-code
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    main: ./cmd/code/main.go
+    ldflags:
+      - -s -w
+      - -X github.com/peeklapp/peekl/cmd/code/commands.version={{.Version}}
+      - -X github.com/peeklapp/peekl/cmd/code/commands.commit={{.Commit}}
+      - -X github.com/peeklapp/peekl/cmd/code/commands.date={{.CommitDate}}
+
 nfpms:
   - id: agent
     package_name: peekl-agent
     ids: ["agent"]
-    vendor: Your Organization
-    homepage: https://example.com/binary1
-    maintainer: Your Name <your.email@example.com>
-    description: Description for binary1
+    vendor: Peekl
+    homepage: https://peekl.dev
+    maintainer: Peekl
+    description: The agent for Peekl
     license: MIT
     formats:
       - deb
@@ -66,10 +82,10 @@ nfpms:
   - id: server
     package_name: peekl-server
     ids: ["server"]
-    vendor: Your Organization
-    homepage: https://example.com/binary2
-    maintainer: Your Name <your.email@example.com>
-    description: Description for binary2
+    vendor: Peekl
+    homepage: https://peekl.dev
+    maintainer: Peekl
+    description: The server for Peekl
     license: MIT
     formats:
       - deb
@@ -79,6 +95,18 @@ nfpms:
         dst: /etc/systemd/system/peekl-server.service
     scripts:
       postinstall: scripts/peekl-server/postinstall.sh
+
+  - id: code
+    package_name: peekl-code
+    ids: ["code"]
+    vendor: Peekl
+    homepage: "https://peekl.dev"
+    maintainer: Peekl
+    description: CLI tool to manage your Peekl code
+    license: MIT
+    formats:
+      - deb
+    bindir: /usr/bin
 
 archives:
   - id: peekl

--- a/cmd/agent/commands/run.go
+++ b/cmd/agent/commands/run.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/peeklapp/peekl/pkg/bootstrap"
 	"github.com/peeklapp/peekl/pkg/catalog"
+	"github.com/peeklapp/peekl/pkg/environments"
 	"github.com/peeklapp/peekl/pkg/facts"
 	"github.com/peeklapp/peekl/pkg/models"
 
@@ -153,6 +154,10 @@ var RunCmd = &cobra.Command{
 			if agentConfig.Environment != environment {
 				environment = agentConfig.Environment
 			}
+		}
+
+		if !environments.EnvironmentNameIsValid(environment) {
+			logrus.Fatalf("'%s' is not a valid environment name", environment)
 		}
 
 		if daemon {

--- a/cmd/agent/commands/run.go
+++ b/cmd/agent/commands/run.go
@@ -139,6 +139,22 @@ var RunCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		// Get environment to use from CLI
+		environment := ""
+
+		argEnvironment, err := cmd.Flags().GetString("environment")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		if cmd.Flags().Changed("environment") {
+			environment = argEnvironment
+		} else {
+			if agentConfig.Environment != environment {
+				environment = agentConfig.Environment
+			}
+		}
+
 		if daemon {
 			for {
 				err = performBootstrap(agentConfig)
@@ -159,7 +175,7 @@ var RunCmd = &cobra.Command{
 			for {
 				if !isLocked() {
 					createLockfile()
-					runAgent(apiClient, agentConfig.Environment)
+					runAgent(apiClient, environment)
 					deleteLockFile()
 				} else {
 					logrus.Error("Could not run agent, it's locked. (/tmp/.peekl_run exist)")
@@ -178,7 +194,7 @@ var RunCmd = &cobra.Command{
 					logrus.Fatal(err)
 				}
 				createLockfile()
-				runAgent(apiClient, agentConfig.Environment)
+				runAgent(apiClient, environment)
 				deleteLockFile()
 			} else {
 				logrus.Error("Could not run agent, it's locked. (/tmp/.peekl_run exist)")

--- a/cmd/agent/commands/run.go
+++ b/cmd/agent/commands/run.go
@@ -142,20 +142,18 @@ var RunCmd = &cobra.Command{
 
 		// Get environment to use from CLI
 		environment := ""
-
-		argEnvironment, err := cmd.Flags().GetString("environment")
-		if err != nil {
-			logrus.Fatal(err)
-		}
-
 		if cmd.Flags().Changed("environment") {
-			environment = argEnvironment
+			environment, err = cmd.Flags().GetString("environment")
+			if err != nil {
+				logrus.Fatal(err)
+			}
 		} else {
 			if agentConfig.Environment != environment {
 				environment = agentConfig.Environment
 			}
 		}
 
+		// Validate that the environment is valid
 		if !environments.EnvironmentNameIsValid(environment) {
 			logrus.Fatalf("'%s' is not a valid environment name", environment)
 		}

--- a/cmd/code/commands/clean.go
+++ b/cmd/code/commands/clean.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"github.com/peeklapp/peekl/pkg/code"
+	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var CleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Remove any stale repository from staging folder",
+	Run: func(cmd *cobra.Command, args []string) {
+		verbose, err := cmd.Flags().GetBool("verbose")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if verbose {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+
+		// Load configuration
+		configPath, err := cmd.Flags().GetString("config")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		conf, err := config.NewCodeConfiguration(configPath)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		err = code.Clean(conf)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+	},
+}

--- a/cmd/code/commands/delete.go
+++ b/cmd/code/commands/delete.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"github.com/peeklapp/peekl/pkg/code"
+	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	DeleteCmd.Flags().StringP("environment", "e", "", "Environment to delete from server")
+	DeleteCmd.Flags().BoolP("force", "f", false, "Ignore the 'production' branch protection")
+	DeleteCmd.MarkFlagRequired("environment")
+}
+
+var DeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete an enviroment locally",
+	Run: func(cmd *cobra.Command, args []string) {
+		verbose, err := cmd.Flags().GetBool("verbose")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if verbose {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+
+		// Load configuration
+		configPath, err := cmd.Flags().GetString("config")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		conf, err := config.NewCodeConfiguration(configPath)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		// Get environment
+		environment, err := cmd.Flags().GetString("environment")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		// Get force
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		if environment == "production" && !force {
+			logrus.Fatal("Not deleting environment 'production'. Use --force if you really want to do it.")
+		}
+
+		err = code.Delete(conf, environment)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+	},
+}

--- a/cmd/code/commands/delete.go
+++ b/cmd/code/commands/delete.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"github.com/peeklapp/peekl/pkg/code"
 	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/peeklapp/peekl/pkg/environments"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -39,6 +40,10 @@ var DeleteCmd = &cobra.Command{
 		environment, err := cmd.Flags().GetString("environment")
 		if err != nil {
 			logrus.Fatal(err)
+		}
+
+		if !environments.EnvironmentNameIsValid(environment) {
+			logrus.Fatalf("'%s' is not a valid environment name", environment)
 		}
 
 		// Get force

--- a/cmd/code/commands/sync.go
+++ b/cmd/code/commands/sync.go
@@ -1,10 +1,9 @@
 package commands
 
 import (
-	"log"
-
 	"github.com/peeklapp/peekl/pkg/code"
 	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/peeklapp/peekl/pkg/environments"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -41,9 +40,13 @@ var SyncCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		if !environments.EnvironmentNameIsValid(environment) {
+			logrus.Fatalf("'%s' is not a valid environment name", environment)
+		}
+
 		// Sync environment
 		if err := code.Sync(conf, environment); err != nil {
-			log.Fatal(err)
+			logrus.Fatal(err)
 		}
 	},
 }

--- a/cmd/code/commands/sync.go
+++ b/cmd/code/commands/sync.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"log"
+
+	"github.com/peeklapp/peekl/pkg/code"
+	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	SyncCmd.Flags().StringP("environment", "e", "production", "Environment to sync from distant repository")
+}
+
+var SyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync an enviroment from remote repository",
+	Run: func(cmd *cobra.Command, args []string) {
+		verbose, err := cmd.Flags().GetBool("verbose")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if verbose {
+			logrus.SetLevel(logrus.DebugLevel)
+		}
+
+		// Load configuration
+		configPath, err := cmd.Flags().GetString("config")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		conf, err := config.NewCodeConfiguration(configPath)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		// Get environment to sync
+		environment, err := cmd.Flags().GetString("environment")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		// Sync environment
+		if err := code.Sync(conf, environment); err != nil {
+			log.Fatal(err)
+		}
+	},
+}

--- a/cmd/code/commands/version.go
+++ b/cmd/code/commands/version.go
@@ -1,0 +1,21 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+var VersionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Obtain information about version and compilation",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Name: peekl-code\nVersion: %s\nCommit: %s\nData: %s\n", version, commit, date)
+	},
+}

--- a/cmd/code/main.go
+++ b/cmd/code/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+
+	"github.com/peeklapp/peekl/cmd/code/commands"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "peekl-code",
+	Short: "peekl-code is used to sync the code base of Peekl with distant.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Help()
+			os.Exit(0)
+		}
+	},
+}
+
+func init() {
+	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose (debug) output")
+	rootCmd.PersistentFlags().StringP("config", "c", "/etc/peekl/config/code.yml", "Configuration file to use for peekl-code")
+	rootCmd.AddCommand(commands.CleanCmd)
+	rootCmd.AddCommand(commands.SyncCmd)
+	rootCmd.AddCommand(commands.DeleteCmd)
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/expr-lang/expr v1.17.7
 	github.com/goccy/go-yaml v1.18.0
 	github.com/gofiber/fiber/v3 v3.0.0
+	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.3
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/olekukonko/tablewriter v1.1.2
@@ -25,7 +26,6 @@ require (
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/gofiber/schema v1.6.0 // indirect
 	github.com/gofiber/utils/v2 v2.0.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/pkg/api/endpoints/catalogs.go
+++ b/pkg/api/endpoints/catalogs.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/peeklapp/peekl/pkg/api/requests"
@@ -35,8 +34,14 @@ func PostRetrieveCatalog(ctx fiber.Ctx) error {
 		return nil
 	}
 
-	directoryPath := path.Join(conf.Code.Directory, input.Environment)
-	nodeName := ctx.RequestCtx().TLSConnectionState().PeerCertificates[0].Subject.CommonName
+	directoryPath, err := environments.GetEnvironmentFolder(input.Environment, conf.Code.Directory)
+	if err != nil {
+		ctx.Status(500).JSON(responses.ErrorResponse{
+			Error:   "Internal Server Error",
+			Details: "An issue happened while trying to identify environment folder",
+		})
+		return nil
+	}
 
 	if _, err := os.Stat(directoryPath); os.IsNotExist(err) {
 		ctx.Status(404).JSON(responses.ErrorResponse{
@@ -48,6 +53,7 @@ func PostRetrieveCatalog(ctx fiber.Ctx) error {
 		return nil
 	}
 
+	nodeName := ctx.RequestCtx().TLSConnectionState().PeerCertificates[0].Subject.CommonName
 	resources, loadedRoles, tags, variables, err := catalog.CompileCatalog(directoryPath, nodeName)
 	if err != nil {
 		if errors.As(err, &models.NodeNotFoundError{}) {

--- a/pkg/code/clean.go
+++ b/pkg/code/clean.go
@@ -1,0 +1,96 @@
+package code
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+func getAllDirsInStaging(stagingFolder string) ([]string, error) {
+	entries, err := os.ReadDir(stagingFolder)
+	if err != nil {
+		return nil, err
+	}
+
+	var dirsInStaging []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirsInStaging = append(dirsInStaging, filepath.Join(stagingFolder, e.Name()))
+		}
+	}
+
+	return dirsInStaging, nil
+}
+
+func getAllReferencedDirsInCode(codeFolder string) ([]string, error) {
+	entries, err := os.ReadDir(codeFolder)
+	if err != nil {
+		return nil, err
+	}
+
+	var referenceDirs []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".info") {
+			data, err := os.ReadFile(filepath.Join(codeFolder, e.Name()))
+			if err != nil {
+				return nil, err
+			}
+			referenceDirs = append(referenceDirs, string(data))
+		}
+	}
+
+	return referenceDirs, nil
+}
+
+func findDirsToDelete(dirsInStaging []string, referencedDirs []string) []string {
+	var dirsToDelete []string
+
+	for _, dir := range dirsInStaging {
+		found := false
+		for _, ref := range referencedDirs {
+			if dir == ref {
+				found = true
+			}
+		}
+		if !found {
+			dirsToDelete = append(dirsToDelete, dir)
+		}
+	}
+
+	return dirsToDelete
+}
+
+func Clean(conf *config.CodeConfig) error {
+	logrus.Info("Getting all folders in staging")
+	dirsInStaging, err := getAllDirsInStaging(conf.StagingFolder)
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Getting all referenced folders")
+	referencedDirs, err := getAllReferencedDirsInCode(conf.CodeFolder)
+	if err != nil {
+		return err
+	}
+
+	logrus.Info("Filtering folders not referenced")
+	dirsToDelete := findDirsToDelete(dirsInStaging, referencedDirs)
+	logrus.Info(fmt.Sprintf("Found %d stale folder to delete.", len(dirsToDelete)))
+
+	if len(dirsToDelete) > 0 {
+		logrus.Info("Deleting folders")
+		for _, dir := range dirsToDelete {
+			err := os.RemoveAll(dir)
+			if err != nil {
+				return err
+			}
+
+		}
+	}
+
+	return nil
+}

--- a/pkg/code/delete.go
+++ b/pkg/code/delete.go
@@ -1,0 +1,68 @@
+package code
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+func getAllStagedRepositoryForEnv(stagingFolder string, environment string) ([]string, error) {
+	entries, err := os.ReadDir(stagingFolder)
+	if err != nil {
+		return nil, err
+	}
+
+	var stagedRepositoryForEnv []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), environment) {
+			stagedRepositoryForEnv = append(stagedRepositoryForEnv, filepath.Join(stagingFolder, e.Name()))
+		}
+	}
+
+	return stagedRepositoryForEnv, nil
+}
+
+func Delete(conf *config.CodeConfig, environment string) error {
+	logrus.Info(fmt.Sprintf("Starting deletion of env '%s'", environment))
+
+	infoFilePath := filepath.Join(conf.CodeFolder, fmt.Sprintf("%s.info", environment))
+
+	logrus.Debug(fmt.Sprintf("Checking if info file for env '%s' exist", environment))
+	infoFileExist := true
+	if _, err := os.Stat(infoFilePath); errors.Is(err, os.ErrNotExist) {
+		infoFileExist = false
+	}
+
+	if infoFileExist {
+		logrus.Debug(fmt.Sprintf("Info file for env '%s' exist, deleting it", environment))
+		err := os.Remove(infoFilePath)
+		if err != nil {
+			return err
+		}
+	}
+
+	stagedRepositoryForEnv, err := getAllStagedRepositoryForEnv(conf.StagingFolder, environment)
+	if err != nil {
+		return err
+	}
+
+	if len(stagedRepositoryForEnv) > 0 {
+		logrus.Debug(fmt.Sprintf("Found %d staged folders related to env '%s', deleting them", len(stagedRepositoryForEnv), environment))
+		for _, dir := range stagedRepositoryForEnv {
+			logrus.Debug(dir)
+			err := os.RemoveAll(dir)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	logrus.Info(fmt.Sprintf("Environment '%s' successfully cleared up", environment))
+
+	return nil
+}

--- a/pkg/code/repository.go
+++ b/pkg/code/repository.go
@@ -1,0 +1,120 @@
+package code
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/peeklapp/peekl/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+func startSshAgent() error {
+	command := "ssh-agent"
+	args := []string{"-s"}
+
+	logrus.Debug(fmt.Sprintf("Starting an SSH agent with the following command : %s %s", command, strings.Join(args, " ")))
+	executionOutput := utils.Execute(command, args...)
+	if executionOutput.ErrorDetails.ExitCode != 0 {
+		logrus.WithFields(logrus.Fields{
+			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
+			"stderr":    executionOutput.ErrorDetails.Stderr,
+			"exit_code": executionOutput.ErrorDetails.ExitCode,
+		}).Debug("Could not execute command to start ssh agent")
+		return executionOutput.ErrorDetails
+	}
+
+	for _, line := range strings.Split(executionOutput.Stdout, "\n") {
+		if strings.Contains(line, "SSH_AUTH_SOCK=") {
+			splittedLineOnSemicolon := strings.Split(line, ";")
+			splittedLineOnEqualSign := strings.Split(splittedLineOnSemicolon[0], "=")
+			err := os.Setenv("SSH_AUTH_SOCK", splittedLineOnEqualSign[1])
+			if err != nil {
+				return err
+			}
+		} else if strings.Contains(line, "SSH_AGENT_PID=") {
+			splittedLineOnSemicolon := strings.Split(line, ";")
+			splittedLineOnEqualSign := strings.Split(splittedLineOnSemicolon[0], "=")
+			err := os.Setenv("SSH_AGENT_PID", splittedLineOnEqualSign[1])
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func addKeyToSshAgent(keyPath string) error {
+	command := "ssh-add"
+	args := []string{keyPath}
+
+	logrus.Debug(fmt.Sprintf("Adding an SSH key to SSH agent with the following command : %s %s", command, strings.Join(args, " ")))
+	executionOutput := utils.Execute(command, args...)
+	if executionOutput.ErrorDetails.ExitCode != 0 {
+		logrus.WithFields(logrus.Fields{
+			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
+			"stderr":    executionOutput.ErrorDetails.Stderr,
+			"exit_code": executionOutput.ErrorDetails.ExitCode,
+		}).Debug("Could not execute command to start ssh agent")
+		return executionOutput.ErrorDetails
+	}
+
+	return nil
+}
+
+func killSshAgent() error {
+	command := "ssh-agent"
+	args := []string{"-k"}
+
+	logrus.Debug(fmt.Sprintf("Killing SSH agent with the following command : %s %s", command, strings.Join(args, " ")))
+	executionOutput := utils.Execute(command, args...)
+	if executionOutput.ErrorDetails.ExitCode != 0 {
+		logrus.WithFields(logrus.Fields{
+			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
+			"stderr":    executionOutput.ErrorDetails.Stderr,
+			"exit_code": executionOutput.ErrorDetails.ExitCode,
+		}).Debug("Could not execute command to start ssh agent")
+		return executionOutput.ErrorDetails
+	}
+
+	return nil
+
+}
+
+func cloneRepository(conf *config.RepositoryConfig, branch string, folderPath string) error {
+	doSsh := !strings.HasPrefix(conf.Url, "http")
+	if doSsh {
+		if err := startSshAgent(); err != nil {
+			return err
+		}
+		if err := addKeyToSshAgent(conf.Key); err != nil {
+			return err
+		}
+	}
+
+	command := "git"
+	args := []string{"clone", conf.Url, "--branch", branch, folderPath, "--depth", "1"}
+
+	logrus.Info(fmt.Sprintf("Cloning repository on branch '%s'", branch))
+	logrus.Debug(fmt.Sprintf("Cloning repository with following command : %s %s", command, strings.Join(args, " ")))
+	executionOutput := utils.Execute(command, args...)
+	if executionOutput.ErrorDetails.ExitCode != 0 {
+		logrus.WithFields(logrus.Fields{
+			"command":   fmt.Sprintf("%s %s", command, strings.Join(args, " ")),
+			"stderr":    executionOutput.ErrorDetails.Stderr,
+			"exit_code": executionOutput.ErrorDetails.ExitCode,
+		}).Debug("Could not execute command to clone directory")
+		return executionOutput.ErrorDetails
+	}
+	logrus.Info("Finshed cloning repository")
+
+	if doSsh {
+		if err := killSshAgent(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/code/sync.go
+++ b/pkg/code/sync.go
@@ -1,0 +1,68 @@
+package code
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/peeklapp/peekl/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+func createInfoFile(environment string, codeFolder string, repositoryPath string) error {
+	infoFilePath := filepath.Join(codeFolder, fmt.Sprintf("%s.info", environment))
+	logrus.Debug(fmt.Sprintf("Creating info file at following path : %s", infoFilePath))
+
+	exist := true
+	if _, err := os.Stat(infoFilePath); errors.Is(err, os.ErrNotExist) {
+		exist = false
+	}
+
+	if exist {
+		err := os.Remove(infoFilePath)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := os.WriteFile(infoFilePath, []byte(repositoryPath), 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Sync(conf *config.CodeConfig, environment string) error {
+	if _, err := os.Stat(conf.StagingFolder); errors.Is(err, os.ErrNotExist) {
+		logrus.Debug(fmt.Sprintf("%s (staging folder) does not exist, creating it.", conf.StagingFolder))
+		if err := os.MkdirAll(conf.StagingFolder, 0750); err != nil {
+			return fmt.Errorf("Could not create staging folder : %s", err.Error())
+		}
+	}
+
+	if _, err := os.Stat(conf.CodeFolder); errors.Is(err, os.ErrNotExist) {
+		logrus.Debug(fmt.Sprintf("%s (code folder) does not exist, creating it.", conf.CodeFolder))
+		if err := os.MkdirAll(conf.CodeFolder, 0750); err != nil {
+			return fmt.Errorf("Could not create code folder : %s", err.Error())
+		}
+	}
+
+	repositoryName := fmt.Sprintf("%s-%s", environment, uuid.New())
+	repositoryPath := filepath.Join(conf.StagingFolder, repositoryName)
+	logrus.Debug(fmt.Sprintf("Repository path to clone into is : %s", repositoryPath))
+
+	err := cloneRepository(&conf.Repository, environment, repositoryPath)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	err = createInfoFile(environment, conf.CodeFolder, repositoryPath)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	return nil
+}

--- a/pkg/config/code.go
+++ b/pkg/config/code.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/mitchellh/mapstructure"
+	"github.com/peeklapp/peekl/pkg/models"
+)
+
+type RepositoryConfig struct {
+	Key string `yaml:"key"`
+	Url string `yaml:"url"`
+}
+
+type CodeConfig struct {
+	pathOfConfigurationFile string
+	CodeFolder              string           `yaml:"code" mapstructure:"code"`
+	StagingFolder           string           `yaml:"staging" mapstructure:"staging"`
+	Repository              RepositoryConfig `yaml:"repository"`
+}
+
+func (c *CodeConfig) Validate() error {
+	validationErrors := []models.ValidationError{}
+
+	if c.Repository.Url == "" {
+		validationErrors = append(validationErrors, models.ValidationError{
+			FieldName:    "repository.url",
+			ViolatedRule: "Field is required",
+		})
+	}
+
+	if !strings.HasPrefix(c.Repository.Url, "http") && c.Repository.Key == "" {
+		validationErrors = append(validationErrors, models.ValidationError{
+			FieldName:    "repository.key",
+			ViolatedRule: "Repository URL appears to be SSH. The key field is required in that case.",
+		})
+	}
+
+	if len(validationErrors) > 0 {
+		return models.ConfigurationValidationError{
+			Path:             c.pathOfConfigurationFile,
+			ValidationErrors: validationErrors,
+		}
+	}
+	return nil
+}
+
+func NewCodeConfiguration(configFilePath string) (*CodeConfig, error) {
+	if _, err := os.Stat(configFilePath); errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("No configuration file found at provided path : %s", configFilePath)
+	}
+
+	var config CodeConfig
+
+	config.pathOfConfigurationFile = configFilePath
+
+	defaults := map[string]any{
+		"code":    "/etc/peekl/code",
+		"staging": "/var/lib/peekl/code",
+	}
+
+	err := mapstructure.Decode(defaults, &config)
+	if err != nil {
+		return &config, err
+	}
+
+	data, err := os.ReadFile(configFilePath)
+	if err != nil {
+		return &config, err
+	}
+
+	var rawYaml map[string]any
+	err = yaml.Unmarshal(data, &rawYaml)
+	if err != nil {
+		return &config, err
+	}
+
+	err = mapstructure.Decode(rawYaml, &config)
+	if err != nil {
+		return &config, err
+	}
+
+	err = config.Validate()
+	if err != nil {
+		return &config, err
+	}
+
+	return &config, nil
+}

--- a/pkg/config/code_test.go
+++ b/pkg/config/code_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadNonExistentConfiguration(t *testing.T) {
+	_, err := NewCodeConfiguration("testdata/code/i_dont_exist.yml")
+	if err == nil {
+		t.Errorf("Should have returned an error because the file doesn't exist.")
+	}
+	assert.Equal(t, "No configuration file found at provided path : testdata/code/i_dont_exist.yml", err.Error())
+}
+
+func TestLoadConfiguration(t *testing.T) {
+	config, err := NewCodeConfiguration("testdata/code/config.yml")
+	if err != nil {
+		t.Errorf("Should not have returned any error : %s", err.Error())
+	}
+
+	assert.Equal(t, "/etc/test/peekl/code", config.CodeFolder)
+	assert.Equal(t, "git@github.com:user/repo.git", config.Repository.Url)
+}
+
+func TestLoadConfigurationWithoutDefaults(t *testing.T) {
+	config, err := NewCodeConfiguration("testdata/code/config_without_defaults.yml")
+	if err != nil {
+		t.Errorf("Shoud not have returned any error : %s", err.Error())
+	}
+	assert.Equal(t, "/etc/peekl/code", config.CodeFolder)
+}

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -25,7 +25,7 @@ type CertificatesConfig struct {
 	BootstrapDnsNames         []string `mapstructure:"bootstrap_dns_names" yaml:"bootstrap_dns_names"`
 }
 
-type CodeConfig struct {
+type ServerCodeConfig struct {
 	Directory string `mapstructure:"directory" yaml:"directory"`
 }
 
@@ -78,7 +78,7 @@ type ServerConfig struct {
 	pathOfConfigurationFile string
 	Listen                  ListenConfig       `mapstructure:"listen" yaml:"listen"`
 	Certificates            CertificatesConfig `mapstructure:"certificates" yaml:"certificates"`
-	Code                    CodeConfig         `mapstructure:"code" yaml:"code"`
+	Code                    ServerCodeConfig   `mapstructure:"code" yaml:"code"`
 	Logging                 LoggingConfig      `mapstructure:"logging" yaml:"logging"`
 	Database                DatabaseConfig     `mapstructure:"database" yaml:"database"`
 }

--- a/pkg/config/server.go
+++ b/pkg/config/server.go
@@ -178,7 +178,7 @@ func NewServerConfiguration(configFilePath string) (*ServerConfig, error) {
 		},
 		"database": map[string]any{
 			"type": "sqlite",
-			"path": "/etc/peekl/data.db",
+			"path": "/var/lib/peekl/data.db",
 			"name": "peekl",
 		},
 	}

--- a/pkg/config/testdata/code/config.yml
+++ b/pkg/config/testdata/code/config.yml
@@ -1,0 +1,6 @@
+code: "/etc/test/peekl/code"
+staging: "/var/lib/test/code"
+
+repository:
+  url: "git@github.com:user/repo.git"
+  key: "/home/peekl/.ssh/id_rsa"

--- a/pkg/config/testdata/code/config_without_defaults.yml
+++ b/pkg/config/testdata/code/config_without_defaults.yml
@@ -1,0 +1,3 @@
+repository:
+  url: "git@github.com:user/repo.git"
+  key: "/home/peekl/.ssh/id_rsa"

--- a/pkg/environments/environments.go
+++ b/pkg/environments/environments.go
@@ -1,8 +1,31 @@
 package environments
 
-import "regexp"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
 
 func EnvironmentNameIsValid(environmentName string) bool {
 	r, _ := regexp.Compile("^[A-Za-z0-9_]")
 	return r.MatchString(environmentName)
+}
+
+func GetEnvironmentFolder(environmentName string, codeDirectory string) (string, error) {
+	environmentFolderPath := ""
+
+	infoFilePath := filepath.Join(codeDirectory, fmt.Sprintf("%s.info", environmentName))
+	if _, err := os.Stat(infoFilePath); errors.Is(err, os.ErrNotExist) {
+		environmentFolderPath = filepath.Join(codeDirectory, environmentName)
+	} else {
+		data, err := os.ReadFile(infoFilePath)
+		if err != nil {
+			return environmentFolderPath, err
+		}
+		environmentFolderPath = string(data)
+	}
+
+	return environmentFolderPath, nil
 }


### PR DESCRIPTION
This commit marks the introduction of a new CLI tool called `peekl-code`. This tool allows you to sync a control repository (from Github, Gitlab...) locally.

It is meant to be used to deploy your Peekl code on your server.