### PR TITLE
fix: make sure roles are only included once

### DIFF
--- a/pkg/catalog/compile.go
+++ b/pkg/catalog/compile.go
@@ -2,10 +2,12 @@ package catalog
 
 import (
 	"maps"
+	"slices"
 
 	"github.com/peeklapp/peekl/pkg/inventory"
 	"github.com/peeklapp/peekl/pkg/models"
 	"github.com/peeklapp/peekl/pkg/roles"
+	"github.com/sirupsen/logrus"
 )
 
 func CompileCatalog(codeDirectory string, nodeName string) ([]models.Resource, []models.Role, []string, map[string]any, error) {
@@ -29,7 +31,12 @@ func CompileCatalog(codeDirectory string, nodeName string) ([]models.Resource, [
 	}
 	tags = append(tags, node.Tags...)
 	nodeVars = node.Variables
-	rolesToLoad = append(rolesToLoad, node.Roles...)
+
+	for _, nodeCurRole := range node.Roles {
+		if !slices.Contains(rolesToLoad, nodeCurRole) {
+			rolesToLoad = append(rolesToLoad, nodeCurRole)
+		}
+	}
 
 	// Handle groups
 	for _, group := range node.Groups {
@@ -42,7 +49,12 @@ func CompileCatalog(codeDirectory string, nodeName string) ([]models.Resource, [
 		}
 		tags = append(tags, groupInv.Tags...)
 		maps.Copy(groupsVars, groupInv.Variables)
-		rolesToLoad = append(rolesToLoad, groupInv.Roles...)
+
+		for _, groupCurRole := range groupInv.Roles {
+			if !slices.Contains(rolesToLoad, groupCurRole) {
+				rolesToLoad = append(rolesToLoad, groupCurRole)
+			}
+		}
 	}
 
 	// Handle roles

--- a/pkg/catalog/compile.go
+++ b/pkg/catalog/compile.go
@@ -7,7 +7,6 @@ import (
 	"github.com/peeklapp/peekl/pkg/inventory"
 	"github.com/peeklapp/peekl/pkg/models"
 	"github.com/peeklapp/peekl/pkg/roles"
-	"github.com/sirupsen/logrus"
 )
 
 func CompileCatalog(codeDirectory string, nodeName string) ([]models.Resource, []models.Role, []string, map[string]any, error) {

--- a/pkg/catalog/compile_test.go
+++ b/pkg/catalog/compile_test.go
@@ -17,6 +17,14 @@ func TestLoadNodeFromCode(t *testing.T) {
 	assert.Equal(t, 0, len(variables))
 }
 
+func TestNoDuplicateRoles(t *testing.T) {
+	_, loadedRoles, _, _, err := CompileCatalog("testdata/duplicate_role", "dummy")
+	if err != nil {
+		t.Errorf("Could not load catalog from code : %s", err.Error())
+	}
+	assert.Equal(t, 2, len(loadedRoles))
+}
+
 func TestLoadNodeMissingGroup(t *testing.T) {
 	_, _, _, _, err := CompileCatalog("testdata/missing_group", "dummy")
 	if err == nil {

--- a/pkg/catalog/testdata/duplicate_role/inventory/groups/web.yml
+++ b/pkg/catalog/testdata/duplicate_role/inventory/groups/web.yml
@@ -1,0 +1,11 @@
+name: "web"
+roles:
+  - "nginx"
+resources:
+  - title: "install_package_cowsay"
+    type: "builtin.pkg"
+    data:
+      names:
+        - "cowsay"
+tags:
+  - "tag_from_group"

--- a/pkg/catalog/testdata/duplicate_role/inventory/nodes/dummy.yml
+++ b/pkg/catalog/testdata/duplicate_role/inventory/nodes/dummy.yml
@@ -1,0 +1,14 @@
+name: "dummy"
+roles:
+  - "test"
+  - "nginx"
+resources:
+  - title: "install_package_htop"
+    type: "builtin.pkg"
+    data:
+      names:
+        - "htop"
+groups:
+  - "web"
+tags:
+  - "tag_from_node"

--- a/pkg/catalog/testdata/duplicate_role/roles/nginx/main.yml
+++ b/pkg/catalog/testdata/duplicate_role/roles/nginx/main.yml
@@ -1,0 +1,9 @@
+resources:
+  - title: "install_package_nginx"
+    type: "builtin.pkg"
+    data:
+      names:
+        - "nginx"
+
+includes:
+  - name: "restart_nginx"

--- a/pkg/catalog/testdata/duplicate_role/roles/nginx/restart_nginx.yml
+++ b/pkg/catalog/testdata/duplicate_role/roles/nginx/restart_nginx.yml
@@ -1,0 +1,5 @@
+- title: "restart_nginx"
+  type: "builtin.systemd_service"
+  data:
+    name: "nginx"
+    state: "restarted"

--- a/pkg/catalog/testdata/duplicate_role/roles/test/main.yml
+++ b/pkg/catalog/testdata/duplicate_role/roles/test/main.yml
@@ -1,0 +1,5 @@
+resources:
+  - title: "test_debug"
+    type: "builtin.debug"
+    data:
+      message: "test"


### PR DESCRIPTION
Previously if you declared a role in both the group for example, and at the node level, you would end up with the role being executed two times. This behavior is not really expected.

Note that in the future roles dependencies might be added so that you could make sure that a role executes only after another role, in case this is required by your business logic.