### PR TITLE
feat: add template and file caching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.19.0
 	modernc.org/sqlite v1.43.0
 )
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -7,6 +7,7 @@ import (
 	"github.com/peeklapp/peekl/internal/api/middlewares/mtls"
 	"github.com/peeklapp/peekl/internal/config"
 	"github.com/peeklapp/peekl/internal/database"
+	"github.com/peeklapp/peekl/internal/filecache"
 )
 
 func NewApiEngine(conf *config.ServerConfig, databaseEngine *database.DatabaseEngine) (*fiber.App, error) {
@@ -62,6 +63,10 @@ func NewApiEngine(conf *config.ServerConfig, databaseEngine *database.DatabaseEn
 	dataGroup := v1.Group("data")
 	dataGroup.Use(mtlsMiddleware)
 
+	// -- Create caches for both templates, and files
+	templateCache := filecache.New()
+	fileCache := filecache.New()
+
 	// -- Data group needs access to server configuration
 	dataGroup.Use(func(c fiber.Ctx) error {
 		c.Locals("config", conf)
@@ -69,8 +74,8 @@ func NewApiEngine(conf *config.ServerConfig, databaseEngine *database.DatabaseEn
 	})
 
 	// -- Data group endpoints
-	dataGroup.Post("/file", endpoints.PostRetrieveFile)
-	dataGroup.Post("/template", endpoints.PostRetrieveTemplate)
+	dataGroup.Post("/file", endpoints.NewPostRetrieveFileHandler(fileCache))
+	dataGroup.Post("/template", endpoints.NewPostretrieveTemplate(templateCache))
 
 	return app, nil
 }

--- a/internal/api/client/data.go
+++ b/internal/api/client/data.go
@@ -8,9 +8,9 @@ import (
 	"github.com/peeklapp/peekl/internal/api/responses"
 )
 
-func (c *Client) RetrieveFile(filename string, environment string, roleName string) (string, error) {
+func (c *Client) RetrieveFile(filename string, environment string, roleName string, agentCacheHash string) (string, error) {
 	endpoint := "/v1/data/file"
-	body := requests.RetrieveFile{Filename: filename, Environment: environment, RoleName: roleName}
+	body := requests.RetrieveFile{Filename: filename, Environment: environment, RoleName: roleName, AgentCacheHash: agentCacheHash}
 	var resp responses.RetrieveFile
 
 	err := c.post(endpoint, &body, &resp)
@@ -26,9 +26,9 @@ func (c *Client) RetrieveFile(filename string, environment string, roleName stri
 	return resp.Content, nil
 }
 
-func (c *Client) RetrieveTemplate(templateName string, environment string, roleName string) (string, error) {
+func (c *Client) RetrieveTemplate(templateName string, environment string, roleName string, agentCacheHash string) (string, error) {
 	endpoint := "/v1/data/template"
-	body := requests.RetrieveTemplate{TemplateName: templateName, Environment: environment, RoleName: roleName}
+	body := requests.RetrieveTemplate{TemplateName: templateName, Environment: environment, RoleName: roleName, AgentCacheHash: agentCacheHash}
 	var resp responses.RetrieveTemplate
 
 	err := c.post(endpoint, &body, &resp)

--- a/internal/api/endpoints/data.go
+++ b/internal/api/endpoints/data.go
@@ -13,198 +13,224 @@ import (
 	"github.com/peeklapp/peekl/internal/api/responses"
 	"github.com/peeklapp/peekl/internal/config"
 	"github.com/peeklapp/peekl/internal/environments"
+	"github.com/peeklapp/peekl/internal/filecache"
 	"github.com/peeklapp/peekl/internal/models"
 	"github.com/peeklapp/peekl/internal/roles"
 )
 
-func PostRetrieveFile(ctx fiber.Ctx) error {
-	var input requests.RetrieveFile
-	if err := ctx.Bind().Body(&input); err != nil {
-		ctx.Status(400).JSON(responses.ErrorResponse{
-			Error:   "Body Invalid",
-			Details: err.Error(),
-		})
-		return nil
-	}
-
-	conf, _ := ctx.Locals("config").(*config.ServerConfig)
-
-	if !roles.RoleNameIsValid(input.RoleName) {
-		ctx.Status(400).JSON(responses.ErrorResponse{
-			Error:   "Role name is not valid",
-			Details: fmt.Sprintf("The provided role name (%s) is not valid.", input.RoleName),
-		})
-		return nil
-	}
-
-	if !environments.EnvironmentNameIsValid(input.Environment) {
-		ctx.Status(400).JSON(responses.ErrorResponse{
-			Error:   "Environment name is not valid",
-			Details: fmt.Sprintf("The provided environment name (%s) is not valid.", input.Environment),
-		})
-	}
-
-	envPath := filepath.Join(conf.Code.Directory, input.Environment)
-	err := roles.DoesRoleExist(envPath, input.RoleName)
-	if err != nil {
-		if errors.As(err, &models.RoleNotFoundError{}) {
-			ctx.Status(404).JSON(responses.ErrorResponse{
-				Error:   "Role could not be found",
-				Details: err.Error(),
-			})
-			return nil
-		} else {
-			ctx.Status(500).JSON(responses.ErrorResponse{
-				Error:   "Internal Server Error",
-				Details: err.Error(),
-			})
-			return nil
-		}
-	}
-
-	roleFilesPath := path.Join(envPath, "roles", input.RoleName, "files")
-	root, err := os.OpenRoot(roleFilesPath)
-	if err != nil {
-		ctx.Status(500).JSON(responses.ErrorResponse{
-			Error:   "Internal Server Error",
-			Details: err.Error(),
-		})
-	}
-
-	if _, err := root.Stat(input.Filename); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+func NewPostRetrieveFileHandler(fileCache *filecache.FileCache) fiber.Handler {
+	return func(ctx fiber.Ctx) error {
+		var input requests.RetrieveFile
+		if err := ctx.Bind().Body(&input); err != nil {
 			ctx.Status(400).JSON(responses.ErrorResponse{
-				Error: "The file does not exist",
-				Details: fmt.Sprintf(
-					"The file '%s' could not be found inside of the role '%s' for environment '%s'",
-					input.Filename,
-					input.RoleName,
-					input.Environment,
-				),
-			})
-			return nil
-		} else {
-			ctx.Status(500).JSON(responses.ErrorResponse{
-				Error:   "Internal Server Error",
+				Error:   "Body Invalid",
 				Details: err.Error(),
 			})
 			return nil
 		}
-	}
 
-	fileContent, err := root.ReadFile(input.Filename)
-	if err != nil {
-		ctx.Status(500).JSON(responses.ErrorResponse{
-			Error:   "Internal Server Error",
-			Details: err.Error(),
+		conf, _ := ctx.Locals("config").(*config.ServerConfig)
+
+		if !roles.RoleNameIsValid(input.RoleName) {
+			ctx.Status(400).JSON(responses.ErrorResponse{
+				Error:   "Role name is not valid",
+				Details: fmt.Sprintf("The provided role name (%s) is not valid.", input.RoleName),
+			})
+			return nil
+		}
+
+		if !environments.EnvironmentNameIsValid(input.Environment) {
+			ctx.Status(400).JSON(responses.ErrorResponse{
+				Error:   "Environment name is not valid",
+				Details: fmt.Sprintf("The provided environment name (%s) is not valid.", input.Environment),
+			})
+		}
+
+		envPath := filepath.Join(conf.Code.Directory, input.Environment)
+		err := roles.DoesRoleExist(envPath, input.RoleName)
+		if err != nil {
+			if errors.As(err, &models.RoleNotFoundError{}) {
+				ctx.Status(404).JSON(responses.ErrorResponse{
+					Error:   "Role could not be found",
+					Details: err.Error(),
+				})
+				return nil
+			} else {
+				ctx.Status(500).JSON(responses.ErrorResponse{
+					Error:   "Internal Server Error",
+					Details: err.Error(),
+				})
+				return nil
+			}
+		}
+
+		roleFilesPath := path.Join(envPath, "roles", input.RoleName, "files")
+		root, err := os.OpenRoot(roleFilesPath)
+		if err != nil {
+			ctx.Status(500).JSON(responses.ErrorResponse{
+				Error:   "Internal Server Error",
+				Details: err.Error(),
+			})
+		}
+
+		info, err := fileCache.GetInfo(root, input.Filename, input.RoleName)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				ctx.Status(400).JSON(responses.ErrorResponse{
+					Error: "The file does not exist",
+					Details: fmt.Sprintf(
+						"The file '%s' could not be found inside of the role '%s' for environment '%s'",
+						input.Filename,
+						input.RoleName,
+						input.Environment,
+					),
+				})
+				return nil
+			} else {
+				ctx.Status(500).JSON(responses.ErrorResponse{
+					Error:   "Internal Server Error",
+					Details: err.Error(),
+				})
+				return nil
+			}
+		}
+
+		if info.Hash == input.AgentCacheHash {
+			ctx.Status(200).JSON(responses.RetrieveFile{
+				AgentCacheIsValid: true,
+				Filename:          input.Filename,
+				Content:           "",
+			})
+			return nil
+		}
+
+		fileContent, err := root.ReadFile(input.Filename)
+		if err != nil {
+			ctx.Status(500).JSON(responses.ErrorResponse{
+				Error:   "Internal Server Error",
+				Details: err.Error(),
+			})
+		}
+
+		ctx.Status(200).JSON(responses.RetrieveFile{
+			Filename: input.Filename,
+			Content:  string(fileContent),
 		})
-	}
 
-	ctx.Status(200).JSON(responses.RetrieveFile{
-		Filename: input.Filename,
-		Content:  string(fileContent),
-	})
-	return nil
+		return nil
+	}
 }
 
-func PostRetrieveTemplate(ctx fiber.Ctx) error {
-	var input requests.RetrieveTemplate
-	if err := ctx.Bind().Body(&input); err != nil {
-		ctx.Status(400).JSON(responses.ErrorResponse{
-			Error:   "Body Invalid",
-			Details: err.Error(),
-		})
-		return nil
-	}
-
-	conf, ok := ctx.Locals("config").(*config.ServerConfig)
-	if !ok {
-		ctx.Status(500).JSON(responses.ErrorResponse{
-			Error: "Not OK !!!",
-		})
-	}
-
-	if !roles.RoleNameIsValid(input.RoleName) {
-		ctx.Status(400).JSON(responses.ErrorResponse{
-			Error:   "Role name is not valid",
-			Details: fmt.Sprintf("The provided role name (%s) is not valid.", input.RoleName),
-		})
-		return nil
-	}
-
-	if !environments.EnvironmentNameIsValid(input.Environment) {
-		ctx.Status(400).JSON(responses.ErrorResponse{
-			Error:   "Environment name is not valid",
-			Details: fmt.Sprintf("The provided environment name (%s) is not valid.", input.Environment),
-		})
-	}
-
-	envPath := filepath.Join(conf.Code.Directory, input.Environment)
-	err := roles.DoesRoleExist(envPath, input.RoleName)
-	if err != nil {
-		if errors.As(err, &models.RoleNotFoundError{}) {
-			ctx.Status(404).JSON(responses.ErrorResponse{
-				Error:   "Role could not be found",
-				Details: err.Error(),
-			})
-			return nil
-		} else {
-			ctx.Status(500).JSON(responses.ErrorResponse{
-				Error:   "Internal Server Error",
-				Details: err.Error(),
-			})
-			return nil
-		}
-	}
-
-	roleTemplatesPath := path.Join(envPath, "roles", input.RoleName, "templates")
-	root, err := os.OpenRoot(roleTemplatesPath)
-	if err != nil {
-		ctx.Status(500).JSON(responses.ErrorResponse{
-			Error:   "Internal Server Error",
-			Details: err.Error(),
-		})
-	}
-
-	var templateName string
-	if strings.HasSuffix(input.TemplateName, ".tmpl") {
-		templateName = input.TemplateName
-	} else {
-		templateName = fmt.Sprintf("%s.tmpl", input.TemplateName)
-	}
-
-	if _, err := root.Stat(templateName); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+func NewPostretrieveTemplate(templateCache *filecache.FileCache) fiber.Handler {
+	return func(ctx fiber.Ctx) error {
+		var input requests.RetrieveTemplate
+		if err := ctx.Bind().Body(&input); err != nil {
 			ctx.Status(400).JSON(responses.ErrorResponse{
-				Error: "The template does not exist",
-				Details: fmt.Sprintf(
-					"The template '%s' could not be found inside of the role '%s' for environment '%s'",
-					input.TemplateName,
-					input.RoleName,
-					input.Environment,
-				),
-			})
-			return nil
-		} else {
-			ctx.Status(500).JSON(responses.ErrorResponse{
-				Error:   "Internal Server Error",
+				Error:   "Body Invalid",
 				Details: err.Error(),
 			})
 			return nil
 		}
-	}
 
-	fileContent, err := root.ReadFile(templateName)
-	if err != nil {
-		ctx.Status(500).JSON(responses.ErrorResponse{
-			Error:   "Internal Server Error",
-			Details: err.Error(),
+		conf, ok := ctx.Locals("config").(*config.ServerConfig)
+		if !ok {
+			ctx.Status(500).JSON(responses.ErrorResponse{
+				Error: "Not OK !!!",
+			})
+		}
+
+		if !roles.RoleNameIsValid(input.RoleName) {
+			ctx.Status(400).JSON(responses.ErrorResponse{
+				Error:   "Role name is not valid",
+				Details: fmt.Sprintf("The provided role name (%s) is not valid.", input.RoleName),
+			})
+			return nil
+		}
+
+		if !environments.EnvironmentNameIsValid(input.Environment) {
+			ctx.Status(400).JSON(responses.ErrorResponse{
+				Error:   "Environment name is not valid",
+				Details: fmt.Sprintf("The provided environment name (%s) is not valid.", input.Environment),
+			})
+		}
+
+		envPath := filepath.Join(conf.Code.Directory, input.Environment)
+		err := roles.DoesRoleExist(envPath, input.RoleName)
+		if err != nil {
+			if errors.As(err, &models.RoleNotFoundError{}) {
+				ctx.Status(404).JSON(responses.ErrorResponse{
+					Error:   "Role could not be found",
+					Details: err.Error(),
+				})
+				return nil
+			} else {
+				ctx.Status(500).JSON(responses.ErrorResponse{
+					Error:   "Internal Server Error",
+					Details: err.Error(),
+				})
+				return nil
+			}
+		}
+
+		roleTemplatesPath := path.Join(envPath, "roles", input.RoleName, "templates")
+		root, err := os.OpenRoot(roleTemplatesPath)
+		if err != nil {
+			ctx.Status(500).JSON(responses.ErrorResponse{
+				Error:   "Internal Server Error",
+				Details: err.Error(),
+			})
+		}
+
+		var templateName string
+		if strings.HasSuffix(input.TemplateName, ".tmpl") {
+			templateName = input.TemplateName
+		} else {
+			templateName = fmt.Sprintf("%s.tmpl", input.TemplateName)
+		}
+
+		info, err := templateCache.GetInfo(root, templateName, input.RoleName)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				ctx.Status(404).JSON(responses.ErrorResponse{
+					Error: "The template does not exist",
+					Details: fmt.Sprintf(
+						"The template '%s' could not be found inside of the role '%s' for environment '%s'",
+						input.TemplateName,
+						input.RoleName,
+						input.Environment,
+					),
+				})
+				return nil
+			} else {
+				ctx.Status(500).JSON(responses.ErrorResponse{
+					Error:   "Internel Server Error",
+					Details: err.Error(),
+				})
+				return nil
+			}
+		}
+
+		if info.Hash == input.AgentCacheHash {
+			ctx.Status(200).JSON(responses.RetrieveTemplate{
+				AgentCacheIsValid: true,
+				TemplateName:      input.TemplateName,
+				Content:           "",
+			})
+			return nil
+		}
+
+		fileContent, err := root.ReadFile(templateName)
+		if err != nil {
+			ctx.Status(500).JSON(responses.ErrorResponse{
+				Error:   "Internal Server Error",
+				Details: err.Error(),
+			})
+		}
+
+		ctx.Status(200).JSON(responses.RetrieveFile{
+			Filename: input.TemplateName,
+			Content:  string(fileContent),
 		})
+		return nil
 	}
-
-	ctx.Status(200).JSON(responses.RetrieveFile{
-		Filename: input.TemplateName,
-		Content:  string(fileContent),
-	})
-	return nil
 }

--- a/internal/api/requests/data.go
+++ b/internal/api/requests/data.go
@@ -1,13 +1,15 @@
 package requests
 
 type RetrieveFile struct {
-	RoleName    string `json:"role_name"`
-	Environment string `json:"environment"`
-	Filename    string `json:"filename"`
+	RoleName       string `json:"role_name"`
+	Environment    string `json:"environment"`
+	Filename       string `json:"filename"`
+	AgentCacheHash string `json:"hash"`
 }
 
 type RetrieveTemplate struct {
-	RoleName     string `json:"role_name"`
-	Environment  string `json:"environment"`
-	TemplateName string `json:"template_name"`
+	RoleName       string `json:"role_name"`
+	Environment    string `json:"environment"`
+	TemplateName   string `json:"template_name"`
+	AgentCacheHash string `json:"hash"`
 }

--- a/internal/api/responses/data.go
+++ b/internal/api/responses/data.go
@@ -1,11 +1,13 @@
 package responses
 
 type RetrieveFile struct {
-	Filename string
-	Content  string
+	AgentCacheIsValid bool
+	Filename          string
+	Content           string
 }
 
 type RetrieveTemplate struct {
-	TemplateName string
-	Content      string
+	AgentCacheIsValid bool
+	TemplateName      string
+	Content           string
 }

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -32,11 +32,18 @@ type AgentLoggingConfig struct {
 	Debug  bool   `mapstructure:"debug" yaml:"debug"`
 }
 
+type AgentCachingConfig struct {
+	TemplateCacheFolder string `mapstructure:"template_cache_folder" yaml:"template_cache_folder"`
+	TemplateCacheBypass bool   `mapstructure:"template_cache_bypass" yaml:"template_cache_bypass"`
+	FileCacheBypass     bool   `mapstructure:"file_cache_bypass" yaml:"file_cache_bypass"`
+}
+
 type AgentConfig struct {
 	Server       AgentServerConfig      `mapstructure:"server" yaml:"server"`
 	Certificates AgentCertificateConfig `mapstructure:"certificates" yaml:"certificates"`
 	Daemon       AgentDaemonConfig      `mapstructure:"daemon" yaml:"daemon"`
 	Logging      AgentLoggingConfig     `mapstructure:"logging" yaml:"logging"`
+	Caching      AgentCachingConfig     `mapstructure:"caching" yaml:"caching"`
 	Environment  string                 `mapstructure:"environment" yaml:"environment"`
 }
 
@@ -63,6 +70,11 @@ func NewAgentConfiguration(configFilePath string) (*AgentConfig, error) {
 		"logging": map[string]any{
 			"format": "string",
 			"debug":  false,
+		},
+		"caching": map[string]any{
+			"template_cache_folder": "/var/lib/peekl/template_cache",
+			"template_cache_bypass": false,
+			"file_cache_bypass":     false,
 		},
 		"environment": "production",
 	}

--- a/internal/config/agent_test.go
+++ b/internal/config/agent_test.go
@@ -23,6 +23,9 @@ func TestLoadConfigurationAgent(t *testing.T) {
 	assert.Equal(t, 3600, config.Daemon.LoopTime)
 	assert.Equal(t, "json", config.Logging.Format)
 	assert.Equal(t, true, config.Logging.Debug)
+	assert.Equal(t, "/tmp", config.Caching.TemplateCacheFolder)
+	assert.Equal(t, true, config.Caching.TemplateCacheBypass)
+	assert.Equal(t, true, config.Caching.FileCacheBypass)
 	assert.Equal(t, "testing", config.Environment)
 }
 
@@ -43,5 +46,8 @@ func TestLoadConfigurationWithoutDefaultsAgent(t *testing.T) {
 	assert.Equal(t, 1800, config.Daemon.LoopTime)
 	assert.Equal(t, "string", config.Logging.Format)
 	assert.Equal(t, false, config.Logging.Debug)
+	assert.Equal(t, "/var/lib/peekl/template_cache", config.Caching.TemplateCacheFolder)
+	assert.Equal(t, false, config.Caching.TemplateCacheBypass)
+	assert.Equal(t, false, config.Caching.FileCacheBypass)
 	assert.Equal(t, "production", config.Environment)
 }

--- a/internal/config/testdata/agent/config.yml
+++ b/internal/config/testdata/agent/config.yml
@@ -10,12 +10,16 @@ certificates:
   bootstrap_pending_file_path: "/var/lib/peekl/ssl/agent/.bootstrap_pending"
   bootstrap_complete_file_path: "/var/lib/peekl/ssl/agent/.bootstrap_complete"
 
-
 daemon:
   loop_time: 3600
 
 logging:
   format: "json"
   debug: true
+
+caching:
+  template_cache_folder: "/tmp"
+  template_cache_bypass: true
+  file_cache_bypass: true
 
 environment: "testing"

--- a/internal/filecache/filecache.go
+++ b/internal/filecache/filecache.go
@@ -1,0 +1,90 @@
+package filecache
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+)
+
+type FileInfo struct {
+	Hash    string
+	ModTime int64
+	Size    int64
+}
+
+type FileCache struct {
+	mu      sync.RWMutex
+	entries map[string]FileInfo
+	group   singleflight.Group
+}
+
+func (f *FileCache) GetInfo(root *os.Root, path string, role string) (FileInfo, error) {
+	// Get current file information
+	stat, err := root.Stat(path)
+	if err != nil {
+		return FileInfo{}, err
+	}
+
+	f.mu.RLock()
+	cached, ok := f.entries[fmt.Sprintf("%s-%s", role, path)]
+	f.mu.RUnlock()
+
+	if ok && cached.ModTime == stat.ModTime().UnixNano() && cached.Size == stat.Size() {
+		return cached, nil
+	}
+
+	v, err, _ := f.group.Do(fmt.Sprintf("%s-%s", role, path), func() (any, error) {
+		return f.computeAndStore(root, path, role)
+	})
+	if err != nil {
+		return FileInfo{}, err
+	}
+
+	return v.(FileInfo), nil
+}
+
+func (f *FileCache) computeAndStore(root *os.Root, path string, role string) (FileInfo, error) {
+	stat, err := root.Stat(path)
+	if err != nil {
+		f.mu.RLock()
+		cached, ok := f.entries[fmt.Sprintf("%s-%s", role, path)]
+		f.mu.RUnlock()
+		if ok && cached.ModTime == stat.ModTime().UnixNano() && cached.Size == stat.Size() {
+			return cached, nil
+		}
+	}
+
+	file, err := root.Open(path)
+	if err != nil {
+		return FileInfo{}, err
+	}
+	defer file.Close()
+
+	h := md5.New()
+	if _, err := io.Copy(h, file); err != nil {
+		return FileInfo{}, err
+	}
+
+	info := FileInfo{
+		Hash:    hex.EncodeToString(h.Sum(nil)),
+		ModTime: stat.ModTime().UnixNano(),
+		Size:    stat.Size(),
+	}
+
+	f.mu.Lock()
+	f.entries[fmt.Sprintf("%s-%s", role, path)] = info
+	f.mu.Unlock()
+
+	return info, nil
+}
+
+func New() *FileCache {
+	return &FileCache{
+		entries: make(map[string]FileInfo),
+	}
+}

--- a/internal/models/client.go
+++ b/internal/models/client.go
@@ -5,6 +5,6 @@ type ApiClient interface {
 	SubmitCertificateRequest(string, string) error
 	RetrieveSignedCertificate(string) (string, error)
 	GetCatalog(string) ([]Resource, []Role, []string, map[string]any, error)
-	RetrieveFile(string, string, string) (string, error)
-	RetrieveTemplate(string, string, string) (string, error)
+	RetrieveFile(string, string, string, string) (string, error)
+	RetrieveTemplate(string, string, string, string) (string, error)
 }


### PR DESCRIPTION
**Context** : Peekl should be tought as a solutiont that can scale. In order to not reproduce the errors that other configuration management tool made, we should tune out everything that can result in less IO usage, and fewer operations on the server side that can, in the context of big infrastructure, result in heavy amount of request. 

Templates and files are currently handled the same way every time an agent makes a request : We send the file content to the agent every single time. At small scale this behavior is fine, but at a bigger scale, this will cause some issues.

**Goal of this pull request** : The idea with this pull request is to add caching both on the server-side, and on the agent side, to prevent file from being fetched if they don't need to.

The implementation is composed of the following :

- On the agent side we make a difference between template, and files. Templates will be stored "raw" inside a caching folder. When the agent needs to process a template, it will first calculate the hash of the raw file, and use this hash to send it alongside its request for the raw template file to the server. The same behavior is valid for the files, but they are directly used and not stored in intermediate state.

- On the server side, we add a caching handler that will cache information about templates and files as long as the server runs. Once the server is restarted, we assume it's ok for the cache to be cleared. Every time an agent makes a request, we use the hash that has been sent to first check if the version of the file or the template that exist for the agent is already valid. If it's the case, we don't send the file back, and respond to the agent that his cache is valid.

By implementing this, we prevent the server from having to read the file from disk every time if it's not required, as well as preventing unnecessary data to be sent to the agent, which heavily reduce the bandwidth used by the application.